### PR TITLE
Refactor the transfer note and evidence note view details model

### DIFF
--- a/src/EA.Weee.Web.Tests.Unit/Areas/Aatf/ViewModels/ViewEvidenceNoteViewModelTests.cs
+++ b/src/EA.Weee.Web.Tests.Unit/Areas/Aatf/ViewModels/ViewEvidenceNoteViewModelTests.cs
@@ -289,5 +289,27 @@
             //assert
             result.Should().Be(year.ToString());
         }
+
+        [Theory]
+        [InlineData(NoteStatus.Draft, "Draft evidence note")]
+        [InlineData(NoteStatus.Rejected, "Rejected evidence note")]
+        [InlineData(NoteStatus.Approved, "Approved evidence note")]
+        [InlineData(NoteStatus.Returned, "Returned evidence note")]
+        [InlineData(NoteStatus.Submitted, "Submitted evidence note")]
+        [InlineData(NoteStatus.Void, "")]
+        public void TabName_GivenNoteStatus_ShouldHaveCorrectTabName(NoteStatus status, string expected)
+        {
+            //arrange
+            var model = new ViewEvidenceNoteViewModel()
+            {
+                Status = status
+            };
+
+            //act
+            var result = model.TabName;
+
+            //assert
+            result.Should().Be(expected);
+        }
     }
 }

--- a/src/EA.Weee.Web.Tests.Unit/Areas/Scheme/ViewModels/ViewTransferNoteViewModelTests.cs
+++ b/src/EA.Weee.Web.Tests.Unit/Areas/Scheme/ViewModels/ViewTransferNoteViewModelTests.cs
@@ -7,6 +7,7 @@
     using FluentAssertions;
     using Web.Areas.Scheme.ViewModels;
     using Web.Areas.Scheme.ViewModels.ManageEvidenceNotes;
+    using Web.ViewModels.Shared;
     using Xunit;
 
     public class ViewTransferNoteViewModelTests
@@ -16,6 +17,12 @@
         {
             typeof(ViewTransferNoteViewModel).GetProperty("ReferenceDisplay").Should()
                 .BeDecoratedWith<DisplayNameAttribute>(d => d.DisplayName.Equals("Reference ID"));
+        }
+
+        [Fact]
+        public void ViewTransferNoteViewModel_ShouldBeDerivedFrom_ViewEvidenceNoteViewModel()
+        {
+            typeof(ViewTransferNoteViewModel).Should().BeDerivedFrom<ViewEvidenceNoteViewModel>();
         }
 
         [Fact]
@@ -109,7 +116,7 @@
         [ClassData(typeof(NoteStatusCoreData))]
         public void DisplayEditButton_GivenNoteStatusIsNotDraft_ShouldBeFalse(NoteStatus status)
         {
-            if (status == NoteStatus.Draft)
+            if (status == NoteStatus.Draft || status == NoteStatus.Returned)
             {
                 return;
             }

--- a/src/EA.Weee.Web.Tests.Unit/ViewModels/EvidenceNoteViewModelTests.cs
+++ b/src/EA.Weee.Web.Tests.Unit/ViewModels/EvidenceNoteViewModelTests.cs
@@ -161,24 +161,5 @@
 
             model.DisplayReturnedReason.Should().BeTrue();
         }
-
-        [Theory]
-        [InlineData(NoteStatus.Draft, "Draft evidence note")]
-        [InlineData(NoteStatus.Rejected, "Rejected evidence note")]
-        [InlineData(NoteStatus.Approved, "Approved evidence note")]
-        [InlineData(NoteStatus.Returned, "Returned evidence note")]
-        [InlineData(NoteStatus.Submitted, "Submitted evidence note")]
-        [InlineData(NoteStatus.Void, "")]
-        public void TabName_GivenNoteStatus_ShouldHaveCorrectTabName(NoteStatus status, string expected)
-        {
-            //arrange
-            model.Status = status;
-
-            //act
-            var result = model.TabName;
-
-            //assert
-            result.Should().Be(expected);
-        }
     }
 }

--- a/src/EA.Weee.Web/Areas/Scheme/ViewModels/ViewTransferNoteViewModel.cs
+++ b/src/EA.Weee.Web/Areas/Scheme/ViewModels/ViewTransferNoteViewModel.cs
@@ -2,44 +2,20 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.ComponentModel;
     using Core.AatfEvidence;
     using Core.Helpers;
     using ManageEvidenceNotes;
+    using Web.ViewModels.Shared;
 
-    public class ViewTransferNoteViewModel
+    public class ViewTransferNoteViewModel : ViewEvidenceNoteViewModel
     {
-        public Guid SchemeId { get; set; }
-
         public Guid EvidenceNoteId { get; set; }
-
-        public int Reference { get; set; }
-
-        public NoteType Type { get; set; }
-
-        public NoteStatus Status { get; set; }
-
-        [DisplayName("Reference ID")]
-        public string ReferenceDisplay => $"{Type.ToDisplayString()}{Reference}";
-
-        public string SuccessMessage { get; set; }
-
-        public bool DisplayMessage => !string.IsNullOrWhiteSpace(SuccessMessage);
-
-        [DisplayName("Compliance year")]
-        public string ComplianceYearDisplay => ComplianceYear.ToString();
-
-        public int ComplianceYear { get; set; }
-
-        public string RecipientAddress { get; set; }
-
+        
         public string TransferredByAddress { get; set; }
 
         public IList<TotalCategoryValue> TotalCategoryValues { get; set; }
 
         public IList<ViewTransferEvidenceAatfDataViewModel> Summary { get; set; }
-
-        public int? SelectedComplianceYear { get; set; }
 
         public string RedirectTab
         {
@@ -57,7 +33,7 @@
 
         public bool EditMode { get; set; }
 
-        public string TabName
+        public override string TabName
         {
             get
             {
@@ -79,8 +55,8 @@
             }
         }
 
-        public bool DisplayEditButton => Status == NoteStatus.Draft;
-
         public bool ReturnToView { get; set; }
+
+        public new int? SelectedComplianceYear { get; set; }
     }
 }

--- a/src/EA.Weee.Web/ViewModels/Shared/EvidenceNoteViewModel.cs
+++ b/src/EA.Weee.Web/ViewModels/Shared/EvidenceNoteViewModel.cs
@@ -104,27 +104,5 @@
                 return ManageEvidenceOverviewDisplayOption.ViewAllOtherEvidenceNotes.ToDisplayString();
             }
         }
-
-        public string TabName
-        {
-            get
-            {
-                switch (Status)
-                {
-                    case NoteStatus.Draft:
-                        return "Draft evidence note";
-                    case NoteStatus.Rejected:
-                        return "Rejected evidence note";
-                    case NoteStatus.Approved:
-                        return "Approved evidence note";
-                    case NoteStatus.Returned:
-                        return "Returned evidence note";
-                    case NoteStatus.Submitted:
-                        return "Submitted evidence note";
-                    default:
-                        return string.Empty;
-                }
-            }
-        }
     }
 }

--- a/src/EA.Weee.Web/ViewModels/Shared/ViewEvidenceNoteViewModel.cs
+++ b/src/EA.Weee.Web/ViewModels/Shared/ViewEvidenceNoteViewModel.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.ComponentModel;
-    using Areas.Aatf.ViewModels;
     using Core.AatfEvidence;
     using Extensions;
 
@@ -52,5 +51,27 @@
         public bool DisplayH2Title { get; set; }
 
         public int SelectedComplianceYear { get; set; }
+
+        public virtual string TabName
+        {
+            get
+            {
+                switch (Status)
+                {
+                    case NoteStatus.Draft:
+                        return "Draft evidence note";
+                    case NoteStatus.Rejected:
+                        return "Rejected evidence note";
+                    case NoteStatus.Approved:
+                        return "Approved evidence note";
+                    case NoteStatus.Returned:
+                        return "Returned evidence note";
+                    case NoteStatus.Submitted:
+                        return "Submitted evidence note";
+                    default:
+                        return string.Empty;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Change to make ViewTransferNoteViewModel to inherit from ViewEvidenceNoteViewModel to make better re-use and to be able to re-use later on.