### PR TITLE
47539 - AA Add menu option 'View PCS obligation and evidence summary' on choose activity internal screen

### DIFF
--- a/src/EA.Weee.Web.Tests.Unit/Areas/Admin/Controllers/HomeControllerTests.cs
+++ b/src/EA.Weee.Web.Tests.Unit/Areas/Admin/Controllers/HomeControllerTests.cs
@@ -106,11 +106,12 @@
             model.PossibleValues[1].Should().Be(InternalUserActivity.SubmissionsHistory);
             model.PossibleValues[2].Should().Be(InternalUserActivity.ProducerDetails);
             model.PossibleValues[3].Should().Be(InternalUserActivity.ManageEvidenceNotes);
-            model.PossibleValues[4].Should().Be(InternalUserActivity.ManagePcsCharges);
-            model.PossibleValues[5].Should().Be(InternalUserActivity.ManageAatfs);
-            model.PossibleValues[6].Should().Be(InternalUserActivity.ManageAes);
-            model.PossibleValues[7].Should().Be(InternalUserActivity.ManageUsers);
-            model.PossibleValues[8].Should().Be(InternalUserActivity.ViewReports);
+            model.PossibleValues[4].Should().Be(InternalUserActivity.ViewPCSObligationAndEvidenceSummary);
+            model.PossibleValues[5].Should().Be(InternalUserActivity.ManagePcsCharges);
+            model.PossibleValues[6].Should().Be(InternalUserActivity.ManageAatfs);
+            model.PossibleValues[7].Should().Be(InternalUserActivity.ManageAes);
+            model.PossibleValues[8].Should().Be(InternalUserActivity.ManageUsers);
+            model.PossibleValues[9].Should().Be(InternalUserActivity.ViewReports);
         }
 
         [Fact]
@@ -130,12 +131,13 @@
             model.PossibleValues[1].Should().Be(InternalUserActivity.SubmissionsHistory);
             model.PossibleValues[2].Should().Be(InternalUserActivity.ProducerDetails);
             model.PossibleValues[3].Should().Be(InternalUserActivity.ManageEvidenceNotes);
-            model.PossibleValues[4].Should().Be(InternalUserActivity.ManagePcsObligations);
-            model.PossibleValues[5].Should().Be(InternalUserActivity.ManagePcsCharges);
-            model.PossibleValues[6].Should().Be(InternalUserActivity.ManageAatfs);
-            model.PossibleValues[7].Should().Be(InternalUserActivity.ManageAes);
-            model.PossibleValues[8].Should().Be(InternalUserActivity.ManageUsers);
-            model.PossibleValues[9].Should().Be(InternalUserActivity.ViewReports);
+            model.PossibleValues[4].Should().Be(InternalUserActivity.ViewPCSObligationAndEvidenceSummary);
+            model.PossibleValues[5].Should().Be(InternalUserActivity.ManagePcsObligations);
+            model.PossibleValues[6].Should().Be(InternalUserActivity.ManagePcsCharges);
+            model.PossibleValues[7].Should().Be(InternalUserActivity.ManageAatfs);
+            model.PossibleValues[8].Should().Be(InternalUserActivity.ManageAes);
+            model.PossibleValues[9].Should().Be(InternalUserActivity.ManageUsers);
+            model.PossibleValues[10].Should().Be(InternalUserActivity.ViewReports);
         }
 
         [Fact]
@@ -167,6 +169,7 @@
         [InlineData(InternalUserActivity.ViewReports, "ChooseReport")]
         [InlineData(InternalUserActivity.ManagePcsCharges, "SelectAuthority")]
         [InlineData(InternalUserActivity.ManagePcsObligations, "SelectAuthority")]
+        [InlineData(InternalUserActivity.ViewPCSObligationAndEvidenceSummary, "Index")]
         public void HttpPost_ChooseActivity_RedirectsToCorrectControllerAction(string selection, string action)
         {
             // Arrange

--- a/src/EA.Weee.Web/Areas/Admin/Controllers/HomeController.cs
+++ b/src/EA.Weee.Web/Areas/Admin/Controllers/HomeController.cs
@@ -88,6 +88,9 @@
                 case InternalUserActivity.ManageEvidenceNotes:
                     return RedirectToAction("Index", "ManageEvidenceNotes");
 
+                case InternalUserActivity.ViewPCSObligationAndEvidenceSummary:
+                    return RedirectToAction("Index", "Holding");
+
                 case InternalUserActivity.SubmissionsHistory:
                     if (configuration.EnableDataReturns)
                     {
@@ -137,6 +140,7 @@
             viewModel.PossibleValues.Add(InternalUserActivity.SubmissionsHistory);
             viewModel.PossibleValues.Add(InternalUserActivity.ProducerDetails);
             viewModel.PossibleValues.Add(InternalUserActivity.ManageEvidenceNotes);
+            viewModel.PossibleValues.Add(InternalUserActivity.ViewPCSObligationAndEvidenceSummary);
 
             if (configuration.EnablePCSObligations && isAdmin)
             {

--- a/src/EA.Weee.Web/Areas/Admin/ViewModels/Home/InternalUserActivity.cs
+++ b/src/EA.Weee.Web/Areas/Admin/ViewModels/Home/InternalUserActivity.cs
@@ -13,5 +13,6 @@
         public const string ManagePcsObligations = "Manage PCS obligations";
         public const string CreateOrganisation = "Add new organisation";
         public const string ManageEvidenceNotes = "Manage evidence notes";
+        public const string ViewPCSObligationAndEvidenceSummary = "View PCS obligation and evidence summary";
     }
 }


### PR DESCRIPTION
Added a new menu option on the choose activity page View PCS obligation and evidence summary which redirects to a Holding page 