### PR TITLE
Charge uplift for direct Registrant for UK-England including nonUK co…

### DIFF
--- a/src/EA.Weee.DataAccess/DataAccess/ISmallProducerDataAccess.cs
+++ b/src/EA.Weee.DataAccess/DataAccess/ISmallProducerDataAccess.cs
@@ -15,6 +15,20 @@
 
         Task<DirectProducerSubmission> GetCurrentDirectRegistrantSubmissionById(Guid directProducerSubmissionId);
 
+        /// <summary>
+        /// Gets the Direct Registrant charge for the specified compliance year and location,
+        /// using only the latest record (backwards compatible method).
+        /// </summary>
         Task<DirectRegistrantCharge> GetDirectRegistrantChargeByComplianceYear(int complianceYear, bool isNonuk);
+
+        /// <summary>
+        /// Gets the applicable Direct Registrant charge based on compliance year, 
+        /// location (IsNonUk flag), and the effective date.
+        /// Returns the charge with the latest EffectiveFrom date that is on or before the asOfDate.
+        /// </summary>
+        Task<DirectRegistrantCharge> GetDirectRegistrantChargeAsync(
+            int complianceYear,
+            bool isNonUk,
+            DateTime asOfDate);
     }
 }

--- a/src/EA.Weee.DataAccess/DataAccess/SmallProducerDataAccess.cs
+++ b/src/EA.Weee.DataAccess/DataAccess/SmallProducerDataAccess.cs
@@ -66,10 +66,41 @@
             return directRegistrant;
         }
 
+        /// <summary>
+        /// Gets the Direct Registrant charge for the specified compliance year and location,
+        /// using only the latest record (backwards compatible method).
+        /// </summary>
         public async Task<DirectRegistrantCharge> GetDirectRegistrantChargeByComplianceYear(int complianceYear, bool isNonUk)
         {
             return await context.DirectRegistrantCharges.Where(d => d.ComplianceYear == complianceYear && d.IsNonUk == isNonUk)
                                                         .FirstOrDefaultAsync();
+        }
+
+        /// <summary>
+        /// Gets the applicable Direct Registrant charge based on compliance year, 
+        /// location (IsNonUk flag), and the effective date.
+        /// Returns the charge with the latest EffectiveFrom date that is on or before the asOfDate.
+        /// </summary>
+        public async Task<DirectRegistrantCharge> GetDirectRegistrantChargeAsync(
+            int complianceYear,
+            bool isNonUk,
+            DateTime asOfDate)
+        {
+            var charge = await context.DirectRegistrantCharges
+                .Where(c => c.ComplianceYear == complianceYear)
+                .Where(c => c.IsNonUk == isNonUk)
+                .Where(c => c.EffectiveFrom <= asOfDate)
+                .OrderByDescending(c => c.EffectiveFrom)
+                .FirstOrDefaultAsync();
+
+            if (charge == null)
+            {
+                throw new InvalidOperationException(
+                    $"No Direct Registrant charge found for compliance year {complianceYear}, " +
+                    $"IsNonUk={isNonUk}, as of {asOfDate:yyyy-MM-dd}");
+            }
+
+            return charge;
         }
     }
 }

--- a/src/EA.Weee.Database/EA.Weee.Database.csproj
+++ b/src/EA.Weee.Database/EA.Weee.Database.csproj
@@ -477,6 +477,7 @@
     <Content Include="scripts\Update\Release 8\Sprint6\20251106-1732-alter-spgCSVDataBySchemeComplianceYearAndAuthorisedAuthority.sql" />
     <Content Include="scripts\Update\Release 8\Sprint6\20251118-1740-Alter-spgProducerPublicRegisterCSVDataByComplianceYear.sql" />
     <Content Include="scripts\Update\Release 8\Sprint6\20260106-1727-Message_Banner-Changes.sql" />
+    <Content Include="scripts\Update\Release 8\Sprint6\20260201-1400-DirectRegistrantChargeIncreaseFees.sql" />
     <None Include="rebuild-development.bat" />
     <Content Include="scripts\Update\Release 4\20220311-1315-sent-on-for-treatment-report.sql" />
     <Content Include="scripts\Update\Release 4\20220923-1751-remove-weeesenton-table-relation.sql" />

--- a/src/EA.Weee.Database/scripts/Update/Release 8/Sprint6/20260201-1400-DirectRegistrantChargeIncreaseFees.sql
+++ b/src/EA.Weee.Database/scripts/Update/Release 8/Sprint6/20260201-1400-DirectRegistrantChargeIncreaseFees.sql
@@ -93,27 +93,3 @@ END
 
 COMMIT TRANSACTION;
 GO
-
--- Verification query
-PRINT N'';
-PRINT N'=== Verification: All Direct Registrant charges for 2026 ===';
-GO
-
-SELECT 
-    [Id],
-    [ComplianceYear],
-    CONVERT(VARCHAR(10), [EffectiveFrom], 120) AS [EffectiveFrom],
-    [ChargeAmount],
-    CASE [IsNonUk]
-        WHEN 0 THEN 'Scotland/Wales/Northern Ireland'
-        WHEN 1 THEN 'England + Non-UK'
-        ELSE 'Unknown'
-    END AS [AppliesTo],
-    [IsNonUk]
-FROM [Lookup].[DirectRegistrantCharge]
-WHERE [ComplianceYear] = 2026
-ORDER BY [EffectiveFrom] ASC, [IsNonUk] ASC;
-GO
-
-PRINT N'=== April 2026 Direct Registrant fee records added successfully ===';
-GO

--- a/src/EA.Weee.Database/scripts/Update/Release 8/Sprint6/20260201-1400-DirectRegistrantChargeIncreaseFees.sql
+++ b/src/EA.Weee.Database/scripts/Update/Release 8/Sprint6/20260201-1400-DirectRegistrantChargeIncreaseFees.sql
@@ -6,12 +6,6 @@
  * - In the future we just need to create new records for the new compliance year onwards
  */
 
-SET NOCOUNT ON;
-SET XACT_ABORT ON;
-
-
-BEGIN TRANSACTION;
-
 -- England + Non-UK (IsNonUk = 1) - £33
 IF NOT EXISTS (
     SELECT 1 FROM [Lookup].[DirectRegistrantCharge]
@@ -23,12 +17,7 @@ BEGIN
     INSERT INTO [Lookup].[DirectRegistrantCharge]
         ([Id], [ComplianceYear], [EffectiveFrom], [ChargeAmount], [IsNonUk])
     VALUES
-        (NEWID(), 2026, '2026-04-01', 33.00, 1);
-    PRINT N'Added England + Non-UK April 2026 fee: £33.00';
-END
-ELSE
-BEGIN
-    PRINT N'England + Non-UK April 2026 fee record already exists';
+        ('D24429EB-50A0-43AB-8D50-FDBC6085AE92', 2026, '2026-04-01', 33.00, 1);
 END
 
 -- Scotland + Wales + Northern Ireland (IsNonUk = 0) - £30
@@ -42,12 +31,7 @@ BEGIN
     INSERT INTO [Lookup].[DirectRegistrantCharge]
         ([Id], [ComplianceYear], [EffectiveFrom], [ChargeAmount], [IsNonUk])
     VALUES
-        (NEWID(), 2026, '2026-04-01', 30.00, 0);
-    PRINT N'Added Scotland/Wales/Northern Ireland April 2026 fee: £30.00';
-END
-ELSE
-BEGIN
-    PRINT N'Scotland/Wales/Northern Ireland April 2026 fee record already exists';
+        ('1BEE68EC-D70D-4578-AEA8-27047A9A122E', 2026, '2026-04-01', 30.00, 0);
 END
 
 -- Add primary key constraint if it doesn't exist
@@ -60,11 +44,6 @@ IF NOT EXISTS (
 BEGIN
     ALTER TABLE [Lookup].[DirectRegistrantCharge]
     ADD CONSTRAINT [PK_DirectRegistrantCharge] PRIMARY KEY CLUSTERED ([Id] ASC);
-    PRINT N'Added primary key constraint on DirectRegistrantCharge.Id';
-END
-ELSE
-BEGIN
-    PRINT N'Primary key constraint already exists';
 END
 
 -- Create performance index if not exists
@@ -84,12 +63,5 @@ BEGIN
     WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, 
           IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF, 
           ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON);
-    PRINT N'Created performance index: IX_DirectRegistrantCharge_ComplianceYear_IsNonUk_EffectiveFrom';
 END
-ELSE
-BEGIN
-    PRINT N'Performance index already exists';
-END
-
-COMMIT TRANSACTION;
 GO

--- a/src/EA.Weee.Database/scripts/Update/Release 8/Sprint6/20260201-1400-DirectRegistrantChargeIncreaseFees.sql
+++ b/src/EA.Weee.Database/scripts/Update/Release 8/Sprint6/20260201-1400-DirectRegistrantChargeIncreaseFees.sql
@@ -1,0 +1,119 @@
+﻿/*
+ * Add Direct Registrant charges for April 2026 fee increase
+ * Fee Changes (effective April 1, 2026):
+ * - England + Non-UK: £32 → £33 (3.8% increase)
+ * - Scotland/Wales/Northern Ireland: £30 (no change)
+ * - In the future we just need to create new records for the new compliance year onwards
+ */
+
+SET NOCOUNT ON;
+SET XACT_ABORT ON;
+
+
+BEGIN TRANSACTION;
+
+-- England + Non-UK (IsNonUk = 1) - £33
+IF NOT EXISTS (
+    SELECT 1 FROM [Lookup].[DirectRegistrantCharge]
+    WHERE [ComplianceYear] = 2026 
+    AND [EffectiveFrom] = '2026-04-01' 
+    AND [IsNonUk] = 1
+)
+BEGIN
+    INSERT INTO [Lookup].[DirectRegistrantCharge]
+        ([Id], [ComplianceYear], [EffectiveFrom], [ChargeAmount], [IsNonUk])
+    VALUES
+        (NEWID(), 2026, '2026-04-01', 33.00, 1);
+    PRINT N'Added England + Non-UK April 2026 fee: £33.00';
+END
+ELSE
+BEGIN
+    PRINT N'England + Non-UK April 2026 fee record already exists';
+END
+
+-- Scotland + Wales + Northern Ireland (IsNonUk = 0) - £30
+IF NOT EXISTS (
+    SELECT 1 FROM [Lookup].[DirectRegistrantCharge]
+    WHERE [ComplianceYear] = 2026 
+    AND [EffectiveFrom] = '2026-04-01' 
+    AND [IsNonUk] = 0
+)
+BEGIN
+    INSERT INTO [Lookup].[DirectRegistrantCharge]
+        ([Id], [ComplianceYear], [EffectiveFrom], [ChargeAmount], [IsNonUk])
+    VALUES
+        (NEWID(), 2026, '2026-04-01', 30.00, 0);
+    PRINT N'Added Scotland/Wales/Northern Ireland April 2026 fee: £30.00';
+END
+ELSE
+BEGIN
+    PRINT N'Scotland/Wales/Northern Ireland April 2026 fee record already exists';
+END
+
+-- Add primary key constraint if it doesn't exist
+IF NOT EXISTS (
+    SELECT 1 
+    FROM sys.indexes 
+    WHERE object_id = OBJECT_ID('[Lookup].[DirectRegistrantCharge]')
+      AND is_primary_key = 1
+)
+BEGIN
+    ALTER TABLE [Lookup].[DirectRegistrantCharge]
+    ADD CONSTRAINT [PK_DirectRegistrantCharge] PRIMARY KEY CLUSTERED ([Id] ASC);
+    PRINT N'Added primary key constraint on DirectRegistrantCharge.Id';
+END
+ELSE
+BEGIN
+    PRINT N'Primary key constraint already exists';
+END
+
+-- Create performance index if not exists
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes 
+    WHERE [name] = 'IX_DirectRegistrantCharge_ComplianceYear_IsNonUk_EffectiveFrom' 
+    AND [object_id] = OBJECT_ID('[Lookup].[DirectRegistrantCharge]')
+)
+BEGIN
+    CREATE NONCLUSTERED INDEX [IX_DirectRegistrantCharge_ComplianceYear_IsNonUk_EffectiveFrom]
+    ON [Lookup].[DirectRegistrantCharge] (
+        [ComplianceYear] ASC, 
+        [IsNonUk] ASC,
+        [EffectiveFrom] DESC
+    )
+    INCLUDE ([ChargeAmount])
+    WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, 
+          IGNORE_DUP_KEY = OFF, DROP_EXISTING = OFF, ONLINE = OFF, 
+          ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON);
+    PRINT N'Created performance index: IX_DirectRegistrantCharge_ComplianceYear_IsNonUk_EffectiveFrom';
+END
+ELSE
+BEGIN
+    PRINT N'Performance index already exists';
+END
+
+COMMIT TRANSACTION;
+GO
+
+-- Verification query
+PRINT N'';
+PRINT N'=== Verification: All Direct Registrant charges for 2026 ===';
+GO
+
+SELECT 
+    [Id],
+    [ComplianceYear],
+    CONVERT(VARCHAR(10), [EffectiveFrom], 120) AS [EffectiveFrom],
+    [ChargeAmount],
+    CASE [IsNonUk]
+        WHEN 0 THEN 'Scotland/Wales/Northern Ireland'
+        WHEN 1 THEN 'England + Non-UK'
+        ELSE 'Unknown'
+    END AS [AppliesTo],
+    [IsNonUk]
+FROM [Lookup].[DirectRegistrantCharge]
+WHERE [ComplianceYear] = 2026
+ORDER BY [EffectiveFrom] ASC, [IsNonUk] ASC;
+GO
+
+PRINT N'=== April 2026 Direct Registrant fee records added successfully ===';
+GO

--- a/src/EA.Weee.RequestHandlers.Tests.Unit/Shared/SmallProducerSubmissionServiceTests.cs
+++ b/src/EA.Weee.RequestHandlers.Tests.Unit/Shared/SmallProducerSubmissionServiceTests.cs
@@ -6,6 +6,7 @@
     using EA.Weee.Core.Organisations;
     using EA.Weee.Core.Shared;
     using EA.Weee.DataAccess.DataAccess;
+    using EA.Weee.Domain;
     using EA.Weee.Domain.Organisation;
     using EA.Weee.Domain.Producer;
     using EA.Weee.RequestHandlers.Mappings;
@@ -15,6 +16,7 @@
     using FluentAssertions;
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading.Tasks;
     using Xunit;
 
@@ -420,6 +422,440 @@
             // Assert
             result.SubmissionHistory.Should().ContainKey(ComplianceYear);
             result.SubmissionHistory[ComplianceYear].Should().Be(submissionHistoryData);
+        }
+
+        [Theory]
+        [InlineData("2026-03-31", 32.00)] // Before April 1st - old fee
+        [InlineData("2026-04-01", 33.00)] // On April 1st - new fee
+        [InlineData("2026-04-02", 33.00)] // After April 1st - new fee
+        [InlineData("2026-12-31", 33.00)] // End of year - new fee
+        public async Task GetSmallProducerSubmissionData_EnglandOrganisation_ReturnsCorrectFeeBasedOnDate(
+    string dateString, decimal expectedAmount)
+        {
+            // Arrange
+            var testDate = DateTime.Parse(dateString);
+            var directRegistrant = SetupDirectRegistrantWithCountry("UK - England");
+
+            A.CallTo(() => systemDataDataAccess.GetSystemDateTime()).Returns(testDate);
+            A.CallTo(() => smallProducerDataAccess.GetCurrentDirectRegistrantSubmissionByComplianceYear(
+                A<Guid>._, A<int>._)).Returns((DirectProducerSubmission)null);
+
+            var charge = CreateDirectRegistrantCharge(2026, true, expectedAmount);
+            A.CallTo(() => smallProducerDataAccess.GetDirectRegistrantChargeAsync(
+                2026, true, testDate))
+                .Returns(charge);
+
+            // Act
+            EA.Prsd.Core.SystemTime.Freeze(testDate);
+            try
+            {
+                var result = await service.GetSmallProducerSubmissionData(directRegistrant, false);
+
+                // Assert
+                result.DirectRegistrantChargeAmount.Should().Be(expectedAmount);
+                A.CallTo(() => smallProducerDataAccess.GetDirectRegistrantChargeAsync(
+                    2026, true, testDate)).MustHaveHappenedOnceExactly();
+            }
+            finally
+            {
+                EA.Prsd.Core.SystemTime.Unfreeze();
+            }
+        }
+
+        [Theory]
+        [InlineData("2026-03-31", 32.00)] // Before April 1st - old fee
+        [InlineData("2026-04-01", 33.00)] // On April 1st - new fee
+        [InlineData("2026-04-02", 33.00)] // After April 1st - new fee
+        public async Task GetSmallProducerSubmissionData_NonUKOrganisation_ReturnsCorrectFeeBasedOnDate(
+            string dateString, decimal expectedAmount)
+        {
+            // Arrange
+            var testDate = DateTime.Parse(dateString);
+            var directRegistrant = SetupDirectRegistrantWithCountry("France");
+
+            A.CallTo(() => systemDataDataAccess.GetSystemDateTime()).Returns(testDate);
+            A.CallTo(() => smallProducerDataAccess.GetCurrentDirectRegistrantSubmissionByComplianceYear(
+                A<Guid>._, A<int>._)).Returns((DirectProducerSubmission)null);
+
+            var charge = CreateDirectRegistrantCharge(2026, true, expectedAmount);
+            A.CallTo(() => smallProducerDataAccess.GetDirectRegistrantChargeAsync(
+                2026, true, testDate))
+                .Returns(charge);
+
+            // Act
+            EA.Prsd.Core.SystemTime.Freeze(testDate);
+            try
+            {
+                var result = await service.GetSmallProducerSubmissionData(directRegistrant, false);
+
+                // Assert
+                result.DirectRegistrantChargeAmount.Should().Be(expectedAmount);
+                A.CallTo(() => smallProducerDataAccess.GetDirectRegistrantChargeAsync(
+                    2026, true, testDate)).MustHaveHappenedOnceExactly();
+            }
+            finally
+            {
+                EA.Prsd.Core.SystemTime.Unfreeze();
+            }
+        }
+
+        [Theory]
+        [InlineData("UK - Scotland", "2026-03-31")]
+        [InlineData("UK - Scotland", "2026-04-01")]
+        [InlineData("UK - Scotland", "2026-12-31")]
+        [InlineData("UK - Wales", "2026-03-31")]
+        [InlineData("UK - Wales", "2026-04-01")]
+        [InlineData("UK - Wales", "2026-12-31")]
+        [InlineData("UK - Northern Ireland", "2026-03-31")]
+        [InlineData("UK - Northern Ireland", "2026-04-01")]
+        [InlineData("UK - Northern Ireland", "2026-12-31")]
+        public async Task GetSmallProducerSubmissionData_ScotlandWalesNI_FeeAlwaysRemains30(
+            string countryName, string dateString)
+        {
+            // Arrange
+            var testDate = DateTime.Parse(dateString);
+            var directRegistrant = SetupDirectRegistrantWithCountry(countryName);
+
+            A.CallTo(() => systemDataDataAccess.GetSystemDateTime()).Returns(testDate);
+            A.CallTo(() => smallProducerDataAccess.GetCurrentDirectRegistrantSubmissionByComplianceYear(
+                A<Guid>._, A<int>._)).Returns((DirectProducerSubmission)null);
+
+            var charge = CreateDirectRegistrantCharge(2026, false, 30.00m);
+            A.CallTo(() => smallProducerDataAccess.GetDirectRegistrantChargeAsync(
+                2026, false, testDate))
+                .Returns(charge);
+
+            // Act
+            EA.Prsd.Core.SystemTime.Freeze(testDate);
+            try
+            {
+                var result = await service.GetSmallProducerSubmissionData(directRegistrant, false);
+
+                // Assert
+                result.DirectRegistrantChargeAmount.Should().Be(30.00m,
+                    $"{countryName} should have £30 fee on {dateString}");
+                A.CallTo(() => smallProducerDataAccess.GetDirectRegistrantChargeAsync(
+                    2026, false, testDate)).MustHaveHappenedOnceExactly();
+            }
+            finally
+            {
+                EA.Prsd.Core.SystemTime.Unfreeze();
+            }
+        }
+
+        [Fact]
+        public async Task GetSmallProducerSubmissionData_EnglandBeforeApril2026_CallsDataAccessWithCorrectParameters()
+        {
+            // Arrange
+            var testDate = new DateTime(2026, 3, 31);
+            var directRegistrant = SetupDirectRegistrantWithCountry("UK - England");
+
+            A.CallTo(() => systemDataDataAccess.GetSystemDateTime()).Returns(testDate);
+            A.CallTo(() => smallProducerDataAccess.GetCurrentDirectRegistrantSubmissionByComplianceYear(
+                A<Guid>._, A<int>._)).Returns((DirectProducerSubmission)null);
+
+            var charge = CreateDirectRegistrantCharge(2026, true, 32.00m);
+            A.CallTo(() => smallProducerDataAccess.GetDirectRegistrantChargeAsync(
+                2026, true, testDate))
+                .Returns(charge);
+
+            // Act
+            EA.Prsd.Core.SystemTime.Freeze(testDate);
+            try
+            {
+                var result = await service.GetSmallProducerSubmissionData(directRegistrant, false);
+
+                // Assert
+                result.DirectRegistrantChargeAmount.Should().Be(32.00m);
+                A.CallTo(() => smallProducerDataAccess.GetDirectRegistrantChargeAsync(
+                    2026, // complianceYear
+                    true, // isNonUk (England is treated as non-UK for fee purposes)
+                    testDate)) // asOfDate
+                    .MustHaveHappenedOnceExactly();
+            }
+            finally
+            {
+                EA.Prsd.Core.SystemTime.Unfreeze();
+            }
+        }
+
+        [Fact]
+        public async Task GetSmallProducerSubmissionData_EnglandOnApril2026_CallsDataAccessWithCorrectParameters()
+        {
+            // Arrange
+            var testDate = new DateTime(2026, 4, 1);
+            var directRegistrant = SetupDirectRegistrantWithCountry("UK - England");
+
+            A.CallTo(() => systemDataDataAccess.GetSystemDateTime()).Returns(testDate);
+            A.CallTo(() => smallProducerDataAccess.GetCurrentDirectRegistrantSubmissionByComplianceYear(
+                A<Guid>._, A<int>._)).Returns((DirectProducerSubmission)null);
+
+            var charge = CreateDirectRegistrantCharge(2026, true, 33.00m);
+            A.CallTo(() => smallProducerDataAccess.GetDirectRegistrantChargeAsync(
+                2026, true, testDate))
+                .Returns(charge);
+
+            // Act
+            EA.Prsd.Core.SystemTime.Freeze(testDate);
+            try
+            {
+                var result = await service.GetSmallProducerSubmissionData(directRegistrant, false);
+
+                // Assert
+                result.DirectRegistrantChargeAmount.Should().Be(33.00m);
+                A.CallTo(() => smallProducerDataAccess.GetDirectRegistrantChargeAsync(
+                    2026, // complianceYear
+                    true, // isNonUk (England is treated as non-UK for fee purposes)
+                    testDate)) // asOfDate = April 1st
+                    .MustHaveHappenedOnceExactly();
+            }
+            finally
+            {
+                EA.Prsd.Core.SystemTime.Unfreeze();
+            }
+        }
+
+        [Theory]
+        [InlineData("Germany")]
+        [InlineData("France")]
+        [InlineData("Spain")]
+        [InlineData("United States")]
+        [InlineData("China")]
+        public async Task GetSmallProducerSubmissionData_OverseasOrganisations_UseIsNonUkTrue(string countryName)
+        {
+            // Arrange
+            var testDate = new DateTime(2026, 4, 1);
+            var directRegistrant = SetupDirectRegistrantWithCountry(countryName);
+
+            A.CallTo(() => systemDataDataAccess.GetSystemDateTime()).Returns(testDate);
+            A.CallTo(() => smallProducerDataAccess.GetCurrentDirectRegistrantSubmissionByComplianceYear(
+                A<Guid>._, A<int>._)).Returns((DirectProducerSubmission)null);
+
+            var charge = CreateDirectRegistrantCharge(2026, true, 33.00m);
+            A.CallTo(() => smallProducerDataAccess.GetDirectRegistrantChargeAsync(
+                2026, true, testDate))
+                .Returns(charge);
+
+            // Act
+            EA.Prsd.Core.SystemTime.Freeze(testDate);
+            try
+            {
+                await service.GetSmallProducerSubmissionData(directRegistrant, false);
+
+                // Assert - verify IsNonUk = true is used for overseas countries
+                A.CallTo(() => smallProducerDataAccess.GetDirectRegistrantChargeAsync(
+                    2026,
+                    true, // isNonUk should be true for non-UK countries
+                    testDate))
+                    .MustHaveHappenedOnceExactly();
+            }
+            finally
+            {
+                EA.Prsd.Core.SystemTime.Unfreeze();
+            }
+        }
+
+        [Fact]
+        public async Task GetSmallProducerSubmissionData_NullBusinessAddress_UsesDefaultHigherFee()
+        {
+            // Arrange
+            var testDate = new DateTime(2026, 4, 1);
+            var directRegistrant = A.Fake<DirectRegistrant>();
+            var organisation = A.Fake<Organisation>();
+
+            A.CallTo(() => directRegistrant.Id).Returns(directRegistrantId);
+            A.CallTo(() => directRegistrant.Organisation).Returns(organisation);
+            A.CallTo(() => organisation.BusinessAddress).Returns(null); // No business address
+            A.CallTo(() => directRegistrant.DirectProducerSubmissions).Returns(new List<DirectProducerSubmission>());
+
+            A.CallTo(() => systemDataDataAccess.GetSystemDateTime()).Returns(testDate);
+            A.CallTo(() => smallProducerDataAccess.GetCurrentDirectRegistrantSubmissionByComplianceYear(
+                A<Guid>._, A<int>._)).Returns((DirectProducerSubmission)null);
+
+            var charge = CreateDirectRegistrantCharge(2026, true, 33.00m);
+            A.CallTo(() => smallProducerDataAccess.GetDirectRegistrantChargeAsync(
+                2026, true, testDate))
+                .Returns(charge);
+
+            // Act
+            EA.Prsd.Core.SystemTime.Freeze(testDate);
+            try
+            {
+                var result = await service.GetSmallProducerSubmissionData(directRegistrant, false);
+
+                // Assert - should default to higher fee (IsNonUk = true)
+                result.DirectRegistrantChargeAmount.Should().Be(33.00m);
+                A.CallTo(() => smallProducerDataAccess.GetDirectRegistrantChargeAsync(
+                    2026,
+                    true, // defaults to IsNonUk = true when address is null
+                    testDate))
+                    .MustHaveHappenedOnceExactly();
+            }
+            finally
+            {
+                EA.Prsd.Core.SystemTime.Unfreeze();
+            }
+        }
+
+        [Fact]
+        public async Task GetSmallProducerSubmissionData_NullCountry_UsesDefaultHigherFee()
+        {
+            // Arrange
+            var testDate = new DateTime(2026, 4, 1);
+            var directRegistrant = A.Fake<DirectRegistrant>();
+            var organisation = A.Fake<Organisation>();
+            var businessAddress = A.Fake<Address>();
+
+            A.CallTo(() => directRegistrant.Id).Returns(directRegistrantId);
+            A.CallTo(() => directRegistrant.Organisation).Returns(organisation);
+            A.CallTo(() => organisation.BusinessAddress).Returns(businessAddress);
+            A.CallTo(() => businessAddress.Country).Returns(null); // No country
+            A.CallTo(() => directRegistrant.DirectProducerSubmissions).Returns(new List<DirectProducerSubmission>());
+
+            A.CallTo(() => systemDataDataAccess.GetSystemDateTime()).Returns(testDate);
+            A.CallTo(() => smallProducerDataAccess.GetCurrentDirectRegistrantSubmissionByComplianceYear(
+                A<Guid>._, A<int>._)).Returns((DirectProducerSubmission)null);
+
+            var charge = CreateDirectRegistrantCharge(2026, true, 33.00m);
+            A.CallTo(() => smallProducerDataAccess.GetDirectRegistrantChargeAsync(
+                2026, true, testDate))
+                .Returns(charge);
+
+            // Act
+            EA.Prsd.Core.SystemTime.Freeze(testDate);
+            try
+            {
+                var result = await service.GetSmallProducerSubmissionData(directRegistrant, false);
+
+                // Assert - should default to higher fee (IsNonUk = true)
+                result.DirectRegistrantChargeAmount.Should().Be(33.00m);
+                A.CallTo(() => smallProducerDataAccess.GetDirectRegistrantChargeAsync(
+                    2026,
+                    true, // defaults to IsNonUk = true when country is null
+                    testDate))
+                    .MustHaveHappenedOnceExactly();
+            }
+            finally
+            {
+                EA.Prsd.Core.SystemTime.Unfreeze();
+            }
+        }
+
+        [Fact]
+        public async Task GetSmallProducerSubmissionData_2025_UsesCorrectFee()
+        {
+            // Arrange - Test that 2025 fees still work correctly
+            var testDate = new DateTime(2025, 6, 1);
+            var directRegistrant = SetupDirectRegistrantWithCountry("UK - England");
+
+            A.CallTo(() => systemDataDataAccess.GetSystemDateTime()).Returns(testDate);
+            A.CallTo(() => smallProducerDataAccess.GetCurrentDirectRegistrantSubmissionByComplianceYear(
+                A<Guid>._, A<int>._)).Returns((DirectProducerSubmission)null);
+
+            var charge = CreateDirectRegistrantCharge(2025, true, 30.00m);
+            A.CallTo(() => smallProducerDataAccess.GetDirectRegistrantChargeAsync(
+                2025, true, testDate))
+                .Returns(charge);
+
+            // Act
+            EA.Prsd.Core.SystemTime.Freeze(testDate);
+            try
+            {
+                var result = await service.GetSmallProducerSubmissionData(directRegistrant, false);
+
+                // Assert - 2025 should use £30 for England
+                result.DirectRegistrantChargeAmount.Should().Be(30.00m);
+            }
+            finally
+            {
+                EA.Prsd.Core.SystemTime.Unfreeze();
+            }
+        }
+
+        [Theory]
+        [InlineData("uk - england")]
+        [InlineData("UK - ENGLAND")]
+        [InlineData("Uk - England")]
+        [InlineData("UK - scotland")]
+        [InlineData("UK - WALES")]
+        public async Task GetSmallProducerSubmissionData_CountryNameCaseInsensitive_WorksCorrectly(string countryName)
+        {
+            // Arrange
+            var testDate = new DateTime(2026, 4, 1);
+            var directRegistrant = SetupDirectRegistrantWithCountry(countryName);
+
+            A.CallTo(() => systemDataDataAccess.GetSystemDateTime()).Returns(testDate);
+            A.CallTo(() => smallProducerDataAccess.GetCurrentDirectRegistrantSubmissionByComplianceYear(
+                A<Guid>._, A<int>._)).Returns((DirectProducerSubmission)null);
+
+            var isScotlandWalesNI = countryName.Equals("UK - Northern Ireland", StringComparison.OrdinalIgnoreCase) ||
+                                    countryName.Equals("UK - Scotland", StringComparison.OrdinalIgnoreCase) ||
+                                    countryName.Equals("UK - Wales", StringComparison.OrdinalIgnoreCase);
+            
+            var expectedIsNonUk = !isScotlandWalesNI;
+            var expectedAmount = isScotlandWalesNI ? 30.00m : 33.00m;
+
+            var charge = CreateDirectRegistrantCharge(2026, expectedIsNonUk, expectedAmount);
+            A.CallTo(() => smallProducerDataAccess.GetDirectRegistrantChargeAsync(
+                2026, expectedIsNonUk, testDate))
+                .Returns(charge);
+
+            // Act
+            EA.Prsd.Core.SystemTime.Freeze(testDate);
+            try
+            {
+                var result = await service.GetSmallProducerSubmissionData(directRegistrant, false);
+
+                // Assert - should work regardless of case
+                result.DirectRegistrantChargeAmount.Should().Be(expectedAmount);
+            }
+            finally
+            {
+                EA.Prsd.Core.SystemTime.Unfreeze();
+            }
+        }
+
+        /// <summary>
+        /// Sets up a DirectRegistrant with a specific country for testing fee calculations
+        /// </summary>
+        private DirectRegistrant SetupDirectRegistrantWithCountry(string countryName)
+        {
+            var directRegistrant = A.Fake<DirectRegistrant>();
+            var organisation = A.Fake<Organisation>();
+            var businessAddress = A.Fake<Address>();
+
+            // Create a real Country object instead of faking it
+            // Country constructor typically takes (Guid id, string name)
+            var country = new Country(Guid.NewGuid(), countryName);
+
+            A.CallTo(() => businessAddress.Country).Returns(country);
+            A.CallTo(() => organisation.BusinessAddress).Returns(businessAddress);
+            A.CallTo(() => directRegistrant.Organisation).Returns(organisation);
+            A.CallTo(() => directRegistrant.Id).Returns(directRegistrantId);
+            A.CallTo(() => directRegistrant.DirectProducerSubmissions).Returns(new List<DirectProducerSubmission>());
+
+            return directRegistrant;
+        }
+
+        /// <summary>
+        /// Creates a DirectRegistrantCharge for testing.
+        /// Uses ObjectInstantiator to set private properties.
+        /// </summary>
+        private Domain.Lookup.DirectRegistrantCharge CreateDirectRegistrantCharge(
+            int complianceYear,
+            bool isNonUk,
+            decimal amount,
+            DateTime? effectiveFrom = null)
+        {
+            var charge = ObjectInstantiator<Domain.Lookup.DirectRegistrantCharge>.CreateNew();
+
+            ObjectInstantiator<Domain.Lookup.DirectRegistrantCharge>.SetProperty(c => c.Id, Guid.NewGuid(), charge);
+            ObjectInstantiator<Domain.Lookup.DirectRegistrantCharge>.SetProperty(c => c.ComplianceYear, complianceYear, charge);
+            ObjectInstantiator<Domain.Lookup.DirectRegistrantCharge>.SetProperty(c => c.IsNonUk, isNonUk, charge);
+            ObjectInstantiator<Domain.Lookup.DirectRegistrantCharge>.SetProperty(c => c.ChargeAmount, amount, charge);
+            ObjectInstantiator<Domain.Lookup.DirectRegistrantCharge>.SetProperty(c => c.EffectiveFrom, effectiveFrom ?? new DateTime(complianceYear, 1, 1), charge);
+
+            return charge;
         }
 
         private static DirectProducerSubmission CreateSubmission(int year)

--- a/src/EA.Weee.RequestHandlers/Shared/SmallProducerSubmissionService.cs
+++ b/src/EA.Weee.RequestHandlers/Shared/SmallProducerSubmissionService.cs
@@ -9,6 +9,7 @@
     using EA.Weee.Domain.Organisation;
     using EA.Weee.Domain.Producer;
     using EA.Weee.RequestHandlers.Mappings;
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
@@ -65,23 +66,40 @@
                 submissionData.SubmissionHistory.Add(directProducerSubmission.ComplianceYear, history);
             }
 
-            if (submissionData != null && submissionData.CurrentSubmission != null && submissionData.CurrentSubmission.BusinessAddressData != null)
+            // Determine the charge amount based on the organization's business address
+            // The fee is determined by the organisation's registered office or principal place of business
+            // Default to IsNonUk = true (higher fee) if business address or country is not available
+            var countryName = directRegistrant.Organisation?.BusinessAddress?.Country?.Name;
+            bool isNonUk = !IsScotlandWalesOrNorthernIreland(countryName);
+
+            // Get the charge based on current UTC date to ensure date-based pricing
+            var directRegistrantCharge = await smallProducerDataAccess.GetDirectRegistrantChargeAsync(
+                SystemTime.UtcNow.Year,
+                isNonUk,
+                SystemTime.UtcNow);
+
+            if (directRegistrantCharge != null)
             {
-                if (submissionData.CurrentSubmission.BusinessAddressData.CountryName.Equals("UK - Northern Ireland") ||
-                    submissionData.CurrentSubmission.BusinessAddressData.CountryName.Equals("UK - Scotland") ||
-                    submissionData.CurrentSubmission.BusinessAddressData.CountryName.Equals("UK - Wales"))
-                {
-                    var directRegistrantCharge = await smallProducerDataAccess.GetDirectRegistrantChargeByComplianceYear(SystemTime.UtcNow.Year, false);
-                    submissionData.DirectRegistrantChargeAmount = directRegistrantCharge.ChargeAmount;
-                }
-                else
-                {
-                    var directRegistrantCharge = await smallProducerDataAccess.GetDirectRegistrantChargeByComplianceYear(SystemTime.UtcNow.Year, true);
-                    submissionData.DirectRegistrantChargeAmount = directRegistrantCharge.ChargeAmount;
-                }
+                submissionData.DirectRegistrantChargeAmount = directRegistrantCharge.ChargeAmount;
             }
 
             return submissionData;
+        }
+
+        /// <summary>
+        /// Determines if the country is Scotland, Wales, or Northern Ireland.
+        /// These countries have a different (lower) fee structure.
+        /// </summary>
+        private bool IsScotlandWalesOrNorthernIreland(string countryName)
+        {
+            if (string.IsNullOrWhiteSpace(countryName))
+            {
+                return false;
+            }
+
+            return countryName.Equals("UK - Northern Ireland", StringComparison.OrdinalIgnoreCase) ||
+                   countryName.Equals("UK - Scotland", StringComparison.OrdinalIgnoreCase) ||
+                   countryName.Equals("UK - Wales", StringComparison.OrdinalIgnoreCase);
         }
     }
 }


### PR DESCRIPTION
Any DRs registering between now and 31st March 2026 will continue to be charged at the current fee, regardless of which user journey they take on the external UI:

£32 - an organisation with a registered office or PPoB in ‘UK – England’.

£32 - an organisation with a registered office or PPoB outside of the UK.

£30 - an organisation with a registered office or PPoB in ‘UK – Scotland’, ‘UK – Wales’ or ‘UK – Northern Ireland’.