### PR TITLE
Amendment Two - Remove the link ‘Download as PDF’ for ExternalUI.

### DIFF
--- a/src/EA.Weee.Email/Templates/ActivateUserAccount.cshtml
+++ b/src/EA.Weee.Email/Templates/ActivateUserAccount.cshtml
@@ -25,7 +25,7 @@
 <p>Hello,</p>
 <p>Your user account has been created on the Waste electrical and electronic equipment (WEEE) service.</p>
 <p>
-    To use this service you need to <a href="@Model.ActivationUrl">activate your account.</a>
+    To use this service you need to <a href="@Model.ActivationUrl">activate your account.</a> This link expires after 3 hours.
 </p>
 <p>If you didn’t create a user account you don’t need to take any action.</p>
 <p>This is an automated email; do not reply.</p>

--- a/src/EA.Weee.Email/Templates/ActivateUserAccount.txt
+++ b/src/EA.Weee.Email/Templates/ActivateUserAccount.txt
@@ -4,7 +4,7 @@ Hello,
 
 Your user account has been created on the Waste electrical and electronic equipment (WEEE) service.
 
-To use this service you need to click activate your account: @Model.ActivationUrl 
+To use this service you need to click activate your account: @Model.ActivationUrl  This link expires after 3 hours.
 
 If you didn’t create a user account you don’t need to take any action.
 

--- a/src/EA.Weee.Web/Areas/Admin/Views/Aatf/ManageAatfs.cshtml
+++ b/src/EA.Weee.Web/Areas/Admin/Views/Aatf/ManageAatfs.cshtml
@@ -86,8 +86,7 @@
                                                         <input class="govuk-checkboxes__input" id="@id" name="@name" type="checkbox" value="true" @isChecked>
 
                                                         <label class="govuk-label govuk-checkboxes__label" for="@id">
-                                                            @Model.Filter.CompetentAuthorityOptions[i].Abbreviation
-                                                            &nbsp;
+                                                            @Model.Filter.CompetentAuthorityOptions[i].Abbreviation                                                           
                                                         </label>
                                                         <input name="@name" type="hidden" value="false">
                                                     </div>

--- a/src/EA.Weee.Web/Areas/Admin/Views/Account/AccountActivationRequired.cshtml
+++ b/src/EA.Weee.Web/Areas/Admin/Views/Account/AccountActivationRequired.cshtml
@@ -12,7 +12,7 @@
 
     <p>
         We have sent your activation email to <span class="email">@ViewBag.UserEmailAddress</span>.
-        You need to use the link in the email to activate your user account.
+        You need to use the link in the email to activate your user account. This Link expires after 3 hours.
     </p>
 
     <p>If the email address shown above is wrong then you will need to create another user account using the correct email address.</p>

--- a/src/EA.Weee.Web/Areas/Producer/Views/Producer/CheckAnswers.cshtml
+++ b/src/EA.Weee.Web/Areas/Producer/Views/Producer/CheckAnswers.cshtml
@@ -33,9 +33,12 @@
         </a>
     </div>
 
-    <p class="govuk-body">
-        @Html.ActionLink("Download as PDF", "DownloadSubmission", new { displayRegistrationDetails = false }, new { @class = "govuk-link" })
-    </p>
+    @*
+        <p class="govuk-body">
+            @Html.ActionLink("Download as PDF", "DownloadSubmission", new { displayRegistrationDetails = false }, new { @class = "govuk-link" })
+        </p>
+    *@
+
 
     <div class="govuk-!-padding-top-6">
         @(this.WeeeGds().BackToTopLink())

--- a/src/EA.Weee.Web/Areas/Producer/Views/ProducerSubmission/EditRepresentedOrganisationDetails.cshtml
+++ b/src/EA.Weee.Web/Areas/Producer/Views/ProducerSubmission/EditRepresentedOrganisationDetails.cshtml
@@ -20,10 +20,12 @@
     </header>
 
     <p>Provide the address of the non-UK established Small EEE producer you are registering on behalf of.</p>
-    <p>
-        If the producer has previously registered in the UK under the WEEE Regulations through being a member of a producer compliance scheme,
-        include their producer registration number.
-    </p>
+    @*
+        <p>
+            If the producer has previously registered in the UK under the WEEE Regulations through being a member of a producer compliance scheme,
+            include their producer registration number.
+        </p>
+    *@
 
     @using (Html.BeginForm())
     {

--- a/src/EA.Weee.Web/Views/Account/AccountActivationRequired.cshtml
+++ b/src/EA.Weee.Web/Views/Account/AccountActivationRequired.cshtml
@@ -12,7 +12,7 @@
 
     <p>
         We have sent your activation email to <span class="email">@ViewBag.UserEmailAddress</span>.
-        You need to use the link in the email to activate your user account.
+        You need to use the link in the email to activate your user account. This Link expires after 3 hours.
     </p>
 
     <p>If the email address shown above is wrong then you will need to create another user account using the correct email address.</p>

--- a/src/EA.Weee.Web/Views/Shared/Producer/ViewOrganisation/_OrganisationDetailsTabs.cshtml
+++ b/src/EA.Weee.Web/Views/Shared/Producer/ViewOrganisation/_OrganisationDetailsTabs.cshtml
@@ -52,10 +52,13 @@ else
         <div class="govuk-!-padding-bottom-5"></div>
     }
 
-    <p>
-       If this information is not correct, please contact your environmental regulator and they will be able to return your application to you.
-    </p>
-}
+    if (!Model.IsInternalAdmin && !Model.IsInternal )
+    {
+        <p>
+            If this information is not correct, please contact your environmental regulator and they will be able to return your application to you.
+        </p>
+    }
+ }
 
 @if (Model.IsInternalAdmin)
 {

--- a/src/EA.Weee.Web/Views/Shared/Producer/ViewOrganisation/_OrganisationDetailsTabs.cshtml
+++ b/src/EA.Weee.Web/Views/Shared/Producer/ViewOrganisation/_OrganisationDetailsTabs.cshtml
@@ -53,7 +53,7 @@ else
     }
 
     <p>
-        If this information is not correct, please contact your agency and they will be able to return your application to you.
+       If this information is not correct, please contact your environmental regulator and they will be able to return your application to you.
     </p>
 }
 


### PR DESCRIPTION
- During the Direct Registrant user journey on the external UI there is a ‘Check your answers before submitting your application’ screen. At the bottom of this screen there is a link to ‘Download as PDF’.
-This ‘Download as PDF’ link is no longer needed and is removed.
