### PR TITLE
1A - WEEE - Inflationary Charge Uplift - Direct Registrants - updates

### DIFF
--- a/src/EA.Weee.Database/EA.Weee.Database.csproj
+++ b/src/EA.Weee.Database/EA.Weee.Database.csproj
@@ -479,6 +479,7 @@
     <Content Include="scripts\Update\Release 8\Sprint6\20260106-1727-Message_Banner-Changes.sql" />
     <Content Include="scripts\Update\Release 8\Sprint6\20260113-1400-Create-AnnualChargebyYear.sql" />
     <Content Include="scripts\Update\Release 8\Sprint6\20260201-1400-DirectRegistrantChargeIncreaseFees.sql" />
+    <Content Include="scripts\Update\Release 8\Sprint6\20260218-1400-UpdateDirectRegistrantCharge2026.sql" />
     <None Include="rebuild-development.bat" />
     <Content Include="scripts\Update\Release 4\20220311-1315-sent-on-for-treatment-report.sql" />
     <Content Include="scripts\Update\Release 4\20220923-1751-remove-weeesenton-table-relation.sql" />

--- a/src/EA.Weee.Database/scripts/Update/Release 8/Sprint6/20260218-1400-UpdateDirectRegistrantCharge2026.sql
+++ b/src/EA.Weee.Database/scripts/Update/Release 8/Sprint6/20260218-1400-UpdateDirectRegistrantCharge2026.sql
@@ -1,0 +1,12 @@
+/*
+ * Update Direct Registrant charge for 2026 (England + Non-UK)
+ * Fee Change: £33.00 -> £33.48
+ * Record ID: D24429EB-50A0-43AB-8D50-FDBC6085AE92
+ */
+
+UPDATE [Lookup].[DirectRegistrantCharge]
+SET [ChargeAmount] = 33.48
+WHERE [Id] = 'D24429EB-50A0-43AB-8D50-FDBC6085AE92'
+  AND [ComplianceYear] = 2026
+  AND [IsNonUk] = 1;
+GO

--- a/src/EA.Weee.RequestHandlers.Tests.Unit/Shared/SmallProducerSubmissionServiceTests.cs
+++ b/src/EA.Weee.RequestHandlers.Tests.Unit/Shared/SmallProducerSubmissionServiceTests.cs
@@ -426,9 +426,9 @@
 
         [Theory]
         [InlineData("2026-03-31", 32.00)] // Before April 1st - old fee
-        [InlineData("2026-04-01", 33.00)] // On April 1st - new fee
-        [InlineData("2026-04-02", 33.00)] // After April 1st - new fee
-        [InlineData("2026-12-31", 33.00)] // End of year - new fee
+        [InlineData("2026-04-01", 33.48)] // On April 1st - new fee
+        [InlineData("2026-04-02", 33.48)] // After April 1st - new fee
+        [InlineData("2026-12-31", 33.48)] // End of year - new fee
         public async Task GetSmallProducerSubmissionData_EnglandOrganisation_ReturnsCorrectFeeBasedOnDate(
     string dateString, decimal expectedAmount)
         {
@@ -464,8 +464,8 @@
 
         [Theory]
         [InlineData("2026-03-31", 32.00)] // Before April 1st - old fee
-        [InlineData("2026-04-01", 33.00)] // On April 1st - new fee
-        [InlineData("2026-04-02", 33.00)] // After April 1st - new fee
+        [InlineData("2026-04-01", 33.48)] // On April 1st - new fee
+        [InlineData("2026-04-02", 33.48)] // After April 1st - new fee
         public async Task GetSmallProducerSubmissionData_NonUKOrganisation_ReturnsCorrectFeeBasedOnDate(
             string dateString, decimal expectedAmount)
         {
@@ -590,7 +590,7 @@
             A.CallTo(() => smallProducerDataAccess.GetCurrentDirectRegistrantSubmissionByComplianceYear(
                 A<Guid>._, A<int>._)).Returns((DirectProducerSubmission)null);
 
-            var charge = CreateDirectRegistrantCharge(2026, true, 33.00m);
+            var charge = CreateDirectRegistrantCharge(2026, true, 33.48m);
             A.CallTo(() => smallProducerDataAccess.GetDirectRegistrantChargeAsync(
                 2026, true, testDate))
                 .Returns(charge);
@@ -602,7 +602,7 @@
                 var result = await service.GetSmallProducerSubmissionData(directRegistrant, false);
 
                 // Assert
-                result.DirectRegistrantChargeAmount.Should().Be(33.00m);
+                result.DirectRegistrantChargeAmount.Should().Be(33.48m);
                 A.CallTo(() => smallProducerDataAccess.GetDirectRegistrantChargeAsync(
                     2026, // complianceYear
                     true, // isNonUk (England is treated as non-UK for fee purposes)
@@ -631,7 +631,7 @@
             A.CallTo(() => smallProducerDataAccess.GetCurrentDirectRegistrantSubmissionByComplianceYear(
                 A<Guid>._, A<int>._)).Returns((DirectProducerSubmission)null);
 
-            var charge = CreateDirectRegistrantCharge(2026, true, 33.00m);
+            var charge = CreateDirectRegistrantCharge(2026, true, 33.48m);
             A.CallTo(() => smallProducerDataAccess.GetDirectRegistrantChargeAsync(
                 2026, true, testDate))
                 .Returns(charge);
@@ -793,7 +793,7 @@
                                     countryName.Equals("UK - Wales", StringComparison.OrdinalIgnoreCase);
             
             var expectedIsNonUk = !isScotlandWalesNI;
-            var expectedAmount = isScotlandWalesNI ? 30.00m : 33.00m;
+            var expectedAmount = isScotlandWalesNI ? 30.00m : 33.48m;
 
             var charge = CreateDirectRegistrantCharge(2026, expectedIsNonUk, expectedAmount);
             A.CallTo(() => smallProducerDataAccess.GetDirectRegistrantChargeAsync(


### PR DESCRIPTION
Update 2026 Direct Registrant charge to £33.48 for England/Non-UK