### PR TITLE
Update fee logic to use latest business address

### DIFF
--- a/src/EA.Weee.RequestHandlers/Shared/SmallProducerSubmissionService.cs
+++ b/src/EA.Weee.RequestHandlers/Shared/SmallProducerSubmissionService.cs
@@ -66,10 +66,12 @@
                 submissionData.SubmissionHistory.Add(directProducerSubmission.ComplianceYear, history);
             }
 
-            // Determine the charge amount based on the organization's business address
+            // Determine the charge amount based on the business address
+            // Use submission's business address if available, otherwise fall back to organisation's address
             // The fee is determined by the organisation's registered office or principal place of business
             // Default to IsNonUk = true (higher fee) if business address or country is not available
-            var countryName = directRegistrant.Organisation?.BusinessAddress?.Country?.Name;
+            var countryName = currentYearSubmission?.CurrentSubmission?.BusinessAddress?.Country?.Name
+                              ?? directRegistrant.Organisation?.BusinessAddress?.Country?.Name;
             bool isNonUk = !IsScotlandWalesOrNorthernIreland(countryName);
 
             // Get the charge based on current UTC date to ensure date-based pricing


### PR DESCRIPTION
Fee calculation now prioritizes the business address from the current submission, falling back to the organization's address if unavailable. Updated comments to clarify address selection logic for UK/non-UK determination.