### PR TITLE
Add SQL script for Non-UK Online Marketplace charges

### DIFF
--- a/src/EA.Weee.Database/EA.Weee.Database.csproj
+++ b/src/EA.Weee.Database/EA.Weee.Database.csproj
@@ -55,6 +55,7 @@
   <ItemGroup>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Content Include="scripts\Update\Release 8\Sprint6\20260316-0900-Update-Lookup-OnlineMarketplaceCharge.sql" />
     <Content Include="scripts\Create\0001-Permissions-AppRole.sql" />
     <Content Include="Readme.txt" />
     <Content Include="scripts\AliaSQL.exe" />

--- a/src/EA.Weee.Database/scripts/Update/Release 8/Sprint6/20260316-0900-Update-Lookup-OnlineMarketplaceCharge.sql
+++ b/src/EA.Weee.Database/scripts/Update/Release 8/Sprint6/20260316-0900-Update-Lookup-OnlineMarketplaceCharge.sql
@@ -1,0 +1,12 @@
+﻿-- Add Non-UK Online Marketplace charges
+IF NOT EXISTS (SELECT 1 FROM [Lookup].[OnlineMarketplaceCharge] WHERE CompetentAuthority = 0 AND EffectiveFrom = '2025-01-01')
+BEGIN
+    INSERT INTO [Lookup].[OnlineMarketplaceCharge] (Id, CompetentAuthority, Amount, EffectiveFrom)
+    VALUES ('ED6C220E-BC29-4DFC-8A29-681393EEB197', 0, 13631.00, '2025-01-01');  -- NonUK 2025
+END
+
+IF NOT EXISTS (SELECT 1 FROM [Lookup].[OnlineMarketplaceCharge] WHERE CompetentAuthority = 0 AND EffectiveFrom = '2026-04-01')
+BEGIN
+    INSERT INTO [Lookup].[OnlineMarketplaceCharge] (Id, CompetentAuthority, Amount, EffectiveFrom)
+    VALUES ('9F1D4FD9-9FC7-4321-8EF7-B9A6FBE00053', 0, 14653.00, '2026-04-01');  -- NonUK 2026
+END


### PR DESCRIPTION
Added 20260316-0900-Update-Lookup-OnlineMarketplaceCharge.sql to insert new Non-UK Online Marketplace charge records for 2025 and 2026 into the Lookup.OnlineMarketplaceCharge table if they do not already exist.