### PR TITLE
Inserted missing charge for year 2027. Added additional unit test.

### DIFF
--- a/src/EA.Weee.Database/EA.Weee.Database.csproj
+++ b/src/EA.Weee.Database/EA.Weee.Database.csproj
@@ -491,6 +491,7 @@
     <Content Include="scripts\Update\Release 8\Sprint6\20260318-1400-Update-ChargeBandAmount2026.sql" />
     <Content Include="scripts\Update\Release 8\Sprint6\20260318-1400-Update-OnlineMarketPlaceCharge.sql" />
     <Content Include="scripts\Update\Release 8\Sprint6\20260318-1023-Alter-Producer-spgCSVDataBySchemeComplianceYearAndAuthorisedAuthority.sql" />
+    <Content Include="scripts\Update\Release 8\Sprint6\20260410-0900-Insert-AnnualCharge2027.sql" />
     <None Include="rebuild-development.bat" />
     <Content Include="scripts\Update\Release 4\20220311-1315-sent-on-for-treatment-report.sql" />
     <Content Include="scripts\Update\Release 4\20220923-1751-remove-weeesenton-table-relation.sql" />

--- a/src/EA.Weee.Database/scripts/Update/Release 8/Sprint6/20260410-0900-Insert-AnnualCharge2027.sql
+++ b/src/EA.Weee.Database/scripts/Update/Release 8/Sprint6/20260410-0900-Insert-AnnualCharge2027.sql
@@ -1,6 +1,30 @@
--- Fixes for EA annual subsistence charge for compliance year 2027
+-- EA annual subsistence charge uplift (3.8% inflation) effective from 1st April 2026.
+-- New fee: £13,948.13 (up from £13,438.00)
+-- Applies to compliance year 2026 for any new scheme registering after 1st April 2026,
+-- and to compliance year 2027 onwards for all EA schemes.
+-- Non-EA authorities (SEPA, NRW, NIEA) remain at £0.00.
 
 SET NOCOUNT ON;
+
+-- Insert the uplifted annual charge for EA for compliance year 2026 (effective from 1st April 2026)
+-- This covers any new EA schemes approved for 2026 after the uplift date.
+-- The existing 2026 row (£13,438, effective 2026-01-01) remains for schemes that already submitted before April.
+IF NOT EXISTS (
+    SELECT 1 FROM [Lookup].[AnnualChargeByYear]
+    WHERE CompetentAuthorityId = 'A3C2D0DD-53A1-4F6A-99D0-1CCFC87611A8'
+      AND ComplianceYear = 2026
+      AND EffectiveFrom = '2026-04-01'
+)
+BEGIN
+    INSERT INTO [Lookup].[AnnualChargeByYear] ([Id], [CompetentAuthorityId], [ComplianceYear], [AnnualChargeAmount], [EffectiveFrom])
+    VALUES (
+        'B7E3A1D2-8F4C-4E9A-B6D5-2C7F8A9E0B1D',
+        'A3C2D0DD-53A1-4F6A-99D0-1CCFC87611A8',
+        2026,
+        13948.13,
+        '2026-04-01'
+    );
+END
 
 -- Insert the uplifted annual charge for EA for compliance year 2027
 IF NOT EXISTS (
@@ -18,3 +42,56 @@ BEGIN
         '2026-04-01'
     );
 END
+
+-- Insert £0.00 annual charge for SEPA for compliance year 2027
+IF NOT EXISTS (
+    SELECT 1 FROM [Lookup].[AnnualChargeByYear]
+    WHERE CompetentAuthorityId = '78F37814-364B-4FAE-BEB5-DB0439CBF177'
+      AND ComplianceYear = 2027
+)
+BEGIN
+    INSERT INTO [Lookup].[AnnualChargeByYear] ([Id], [CompetentAuthorityId], [ComplianceYear], [AnnualChargeAmount], [EffectiveFrom])
+    VALUES (
+        '6A2B9C3D-E4F5-4A6B-8C7D-9E0F1A2B3C4D',
+        '78F37814-364B-4FAE-BEB5-DB0439CBF177',
+        2027,
+        0.00,
+        '2026-04-01'
+    );
+END
+
+-- Insert £0.00 annual charge for NRW for compliance year 2027
+IF NOT EXISTS (
+    SELECT 1 FROM [Lookup].[AnnualChargeByYear]
+    WHERE CompetentAuthorityId = '44C2F368-AA66-48F0-BBC9-A0ED34AD0951'
+      AND ComplianceYear = 2027
+)
+BEGIN
+    INSERT INTO [Lookup].[AnnualChargeByYear] ([Id], [CompetentAuthorityId], [ComplianceYear], [AnnualChargeAmount], [EffectiveFrom])
+    VALUES (
+        '7B3C0D4E-F5A6-4B7C-9D8E-0F1A2B3C4D5E',
+        '44C2F368-AA66-48F0-BBC9-A0ED34AD0951',
+        2027,
+        0.00,
+        '2026-04-01'
+    );
+END
+
+-- Insert £0.00 annual charge for NIEA for compliance year 2027
+IF NOT EXISTS (
+    SELECT 1 FROM [Lookup].[AnnualChargeByYear]
+    WHERE CompetentAuthorityId = '4EEE5942-01B2-4A4D-855A-34DEE1BBBF26'
+      AND ComplianceYear = 2027
+)
+BEGIN
+    INSERT INTO [Lookup].[AnnualChargeByYear] ([Id], [CompetentAuthorityId], [ComplianceYear], [AnnualChargeAmount], [EffectiveFrom])
+    VALUES (
+        '8C4D1E5F-A6B7-4C8D-0E9F-1A2B3C4D5E6F',
+        '4EEE5942-01B2-4A4D-855A-34DEE1BBBF26',
+        2027,
+        0.00,
+        '2026-04-01'
+    );
+END
+
+GO

--- a/src/EA.Weee.Database/scripts/Update/Release 8/Sprint6/20260410-0900-Insert-AnnualCharge2027.sql
+++ b/src/EA.Weee.Database/scripts/Update/Release 8/Sprint6/20260410-0900-Insert-AnnualCharge2027.sql
@@ -2,7 +2,6 @@
 -- New fee: £13,948.13 (up from £13,438.00)
 -- Applies to compliance year 2026 for any new scheme registering after 1st April 2026,
 -- and to compliance year 2027 onwards for all EA schemes.
--- Non-EA authorities (SEPA, NRW, NIEA) remain at £0.00.
 
 SET NOCOUNT ON;
 
@@ -39,57 +38,6 @@ BEGIN
         'A3C2D0DD-53A1-4F6A-99D0-1CCFC87611A8',
         2027,
         13948.13,
-        '2026-04-01'
-    );
-END
-
--- Insert £0.00 annual charge for SEPA for compliance year 2027
-IF NOT EXISTS (
-    SELECT 1 FROM [Lookup].[AnnualChargeByYear]
-    WHERE CompetentAuthorityId = '78F37814-364B-4FAE-BEB5-DB0439CBF177'
-      AND ComplianceYear = 2027
-)
-BEGIN
-    INSERT INTO [Lookup].[AnnualChargeByYear] ([Id], [CompetentAuthorityId], [ComplianceYear], [AnnualChargeAmount], [EffectiveFrom])
-    VALUES (
-        '6A2B9C3D-E4F5-4A6B-8C7D-9E0F1A2B3C4D',
-        '78F37814-364B-4FAE-BEB5-DB0439CBF177',
-        2027,
-        0.00,
-        '2026-04-01'
-    );
-END
-
--- Insert £0.00 annual charge for NRW for compliance year 2027
-IF NOT EXISTS (
-    SELECT 1 FROM [Lookup].[AnnualChargeByYear]
-    WHERE CompetentAuthorityId = '44C2F368-AA66-48F0-BBC9-A0ED34AD0951'
-      AND ComplianceYear = 2027
-)
-BEGIN
-    INSERT INTO [Lookup].[AnnualChargeByYear] ([Id], [CompetentAuthorityId], [ComplianceYear], [AnnualChargeAmount], [EffectiveFrom])
-    VALUES (
-        '7B3C0D4E-F5A6-4B7C-9D8E-0F1A2B3C4D5E',
-        '44C2F368-AA66-48F0-BBC9-A0ED34AD0951',
-        2027,
-        0.00,
-        '2026-04-01'
-    );
-END
-
--- Insert £0.00 annual charge for NIEA for compliance year 2027
-IF NOT EXISTS (
-    SELECT 1 FROM [Lookup].[AnnualChargeByYear]
-    WHERE CompetentAuthorityId = '4EEE5942-01B2-4A4D-855A-34DEE1BBBF26'
-      AND ComplianceYear = 2027
-)
-BEGIN
-    INSERT INTO [Lookup].[AnnualChargeByYear] ([Id], [CompetentAuthorityId], [ComplianceYear], [AnnualChargeAmount], [EffectiveFrom])
-    VALUES (
-        '8C4D1E5F-A6B7-4C8D-0E9F-1A2B3C4D5E6F',
-        '4EEE5942-01B2-4A4D-855A-34DEE1BBBF26',
-        2027,
-        0.00,
         '2026-04-01'
     );
 END

--- a/src/EA.Weee.Database/scripts/Update/Release 8/Sprint6/20260410-0900-Insert-AnnualCharge2027.sql
+++ b/src/EA.Weee.Database/scripts/Update/Release 8/Sprint6/20260410-0900-Insert-AnnualCharge2027.sql
@@ -1,0 +1,20 @@
+-- Fixes for EA annual subsistence charge for compliance year 2027
+
+SET NOCOUNT ON;
+
+-- Insert the uplifted annual charge for EA for compliance year 2027
+IF NOT EXISTS (
+    SELECT 1 FROM [Lookup].[AnnualChargeByYear]
+    WHERE CompetentAuthorityId = 'A3C2D0DD-53A1-4F6A-99D0-1CCFC87611A8'
+      AND ComplianceYear = 2027
+)
+BEGIN
+    INSERT INTO [Lookup].[AnnualChargeByYear] ([Id], [CompetentAuthorityId], [ComplianceYear], [AnnualChargeAmount], [EffectiveFrom])
+    VALUES (
+        '45F6DE40-5419-4104-8B87-98F6A870DAF3',
+        'A3C2D0DD-53A1-4F6A-99D0-1CCFC87611A8',
+        2027,
+        13948.13,
+        '2026-04-01'
+    );
+END

--- a/src/EA.Weee.Database/scripts/Update/Release 8/Sprint6/20260410-0900-Insert-AnnualCharge2027.sql
+++ b/src/EA.Weee.Database/scripts/Update/Release 8/Sprint6/20260410-0900-Insert-AnnualCharge2027.sql
@@ -5,41 +5,48 @@
 
 SET NOCOUNT ON;
 
--- Insert the uplifted annual charge for EA for compliance year 2026 (effective from 1st April 2026)
--- This covers any new EA schemes approved for 2026 after the uplift date.
--- The existing 2026 row (£13,438, effective 2026-01-01) remains for schemes that already submitted before April.
-IF NOT EXISTS (
-    SELECT 1 FROM [Lookup].[AnnualChargeByYear]
-    WHERE CompetentAuthorityId = 'A3C2D0DD-53A1-4F6A-99D0-1CCFC87611A8'
-      AND ComplianceYear = 2026
-      AND EffectiveFrom = '2026-04-01'
+-- Only insert if the EA competent authority exists
+IF EXISTS (
+    SELECT 1 FROM [Lookup].[CompetentAuthority]
+    WHERE Id = 'A3C2D0DD-53A1-4F6A-99D0-1CCFC87611A8'
 )
 BEGIN
-    INSERT INTO [Lookup].[AnnualChargeByYear] ([Id], [CompetentAuthorityId], [ComplianceYear], [AnnualChargeAmount], [EffectiveFrom])
-    VALUES (
-        'B7E3A1D2-8F4C-4E9A-B6D5-2C7F8A9E0B1D',
-        'A3C2D0DD-53A1-4F6A-99D0-1CCFC87611A8',
-        2026,
-        13948.13,
-        '2026-04-01'
-    );
-END
+    -- Insert the uplifted annual charge for EA for compliance year 2026 (effective from 1st April 2026)
+    -- This covers any new EA schemes approved for 2026 after the uplift date.
+    -- The existing 2026 row (£13,438, effective 2026-01-01) remains for schemes that already submitted before April.
+    IF NOT EXISTS (
+        SELECT 1 FROM [Lookup].[AnnualChargeByYear]
+        WHERE CompetentAuthorityId = 'A3C2D0DD-53A1-4F6A-99D0-1CCFC87611A8'
+          AND ComplianceYear = 2026
+          AND EffectiveFrom = '2026-04-01'
+    )
+    BEGIN
+        INSERT INTO [Lookup].[AnnualChargeByYear] ([Id], [CompetentAuthorityId], [ComplianceYear], [AnnualChargeAmount], [EffectiveFrom])
+        VALUES (
+            'B7E3A1D2-8F4C-4E9A-B6D5-2C7F8A9E0B1D',
+            'A3C2D0DD-53A1-4F6A-99D0-1CCFC87611A8',
+            2026,
+            13948.13,
+            '2026-04-01'
+        );
+    END
 
--- Insert the uplifted annual charge for EA for compliance year 2027
-IF NOT EXISTS (
-    SELECT 1 FROM [Lookup].[AnnualChargeByYear]
-    WHERE CompetentAuthorityId = 'A3C2D0DD-53A1-4F6A-99D0-1CCFC87611A8'
-      AND ComplianceYear = 2027
-)
-BEGIN
-    INSERT INTO [Lookup].[AnnualChargeByYear] ([Id], [CompetentAuthorityId], [ComplianceYear], [AnnualChargeAmount], [EffectiveFrom])
-    VALUES (
-        '45F6DE40-5419-4104-8B87-98F6A870DAF3',
-        'A3C2D0DD-53A1-4F6A-99D0-1CCFC87611A8',
-        2027,
-        13948.13,
-        '2026-04-01'
-    );
+    -- Insert the uplifted annual charge for EA for compliance year 2027
+    IF NOT EXISTS (
+        SELECT 1 FROM [Lookup].[AnnualChargeByYear]
+        WHERE CompetentAuthorityId = 'A3C2D0DD-53A1-4F6A-99D0-1CCFC87611A8'
+          AND ComplianceYear = 2027
+    )
+    BEGIN
+        INSERT INTO [Lookup].[AnnualChargeByYear] ([Id], [CompetentAuthorityId], [ComplianceYear], [AnnualChargeAmount], [EffectiveFrom])
+        VALUES (
+            '45F6DE40-5419-4104-8B87-98F6A870DAF3',
+            'A3C2D0DD-53A1-4F6A-99D0-1CCFC87611A8',
+            2027,
+            13948.13,
+            '2026-04-01'
+        );
+    END
 END
 
 GO

--- a/src/EA.Weee.RequestHandlers.Tests.Unit/Scheme/MemberRegistration/AnnualChargeDataAccessTests.cs
+++ b/src/EA.Weee.RequestHandlers.Tests.Unit/Scheme/MemberRegistration/AnnualChargeDataAccessTests.cs
@@ -44,13 +44,15 @@
         }
 
         [Fact]
-        public async Task GetAnnualChargeForComplianceYear_ReturnsCorrectCharge_For2026()
+        public async Task GetAnnualChargeForComplianceYear_ReturnsUpliftedCharge_For2026_AfterApril2026()
         {
-            // Arrange
+            // Arrange - After 1st April 2026, the uplifted row (£13,948.13) should be returned
+            // because it has the latest EffectiveFrom that is <= now
             var competentAuthorityId = Guid.NewGuid();
             var annualCharges = new List<AnnualChargeByYear>
             {
-                new AnnualChargeByYear(competentAuthorityId, 2026, 13438.00m, new DateTime(2026, 1, 1))
+                new AnnualChargeByYear(competentAuthorityId, 2026, 13438.00m, new DateTime(2026, 1, 1)),
+                new AnnualChargeByYear(competentAuthorityId, 2026, 13948.13m, new DateTime(2026, 4, 1))
             };
 
             var dbSet = helper.GetAsyncEnabledDbSet(annualCharges);
@@ -59,8 +61,8 @@
             // Act
             var result = await dataAccess.GetAnnualChargeForComplianceYear(competentAuthorityId, 2026);
 
-            // Assert
-            Assert.Equal(13438.00m, result);
+            // Assert - Should return the uplifted fee since today is after 1st April 2026
+            Assert.Equal(13948.13m, result);
         }
 
         [Fact]
@@ -91,7 +93,7 @@
             var annualCharges = new List<AnnualChargeByYear>
             {
                 new AnnualChargeByYear(competentAuthorityId, 2026, 13438.00m, new DateTime(2026, 1, 1)),
-                new AnnualChargeByYear(competentAuthorityId, 2026, 14000.00m, new DateTime(2026, 6, 1)) // Mid-year adjustment
+                new AnnualChargeByYear(competentAuthorityId, 2026, 13948.13m, new DateTime(2026, 4, 1))
             };
 
             var dbSet = helper.GetAsyncEnabledDbSet(annualCharges);
@@ -101,7 +103,27 @@
             var result = await dataAccess.GetAnnualChargeForComplianceYear(competentAuthorityId, 2026);
 
             // Assert
-            Assert.Equal(14000.00m, result); // Should return the latest one
+            Assert.Equal(13948.13m, result); // Should return the latest effective one
+        }
+
+        [Fact]
+        public async Task GetAnnualChargeForComplianceYear_FutureEffectiveFrom_IsExcluded()
+        {
+            // Arrange - A record with a future EffectiveFrom should not be returned
+            var competentAuthorityId = Guid.NewGuid();
+            var annualCharges = new List<AnnualChargeByYear>
+            {
+                new AnnualChargeByYear(competentAuthorityId, 2028, 15000.00m, DateTime.UtcNow.AddYears(1))
+            };
+
+            var dbSet = helper.GetAsyncEnabledDbSet(annualCharges);
+            A.CallTo(() => context.AnnualChargesByYear).Returns(dbSet);
+
+            // Act
+            var result = await dataAccess.GetAnnualChargeForComplianceYear(competentAuthorityId, 2028);
+
+            // Assert
+            Assert.Null(result);
         }
 
         [Fact]
@@ -201,6 +223,7 @@
                 new AnnualChargeByYear(competentAuthorityId, 2024, 12500.00m, new DateTime(2024, 1, 1)),
                 new AnnualChargeByYear(competentAuthorityId, 2025, 12500.00m, new DateTime(2025, 1, 1)),
                 new AnnualChargeByYear(competentAuthorityId, 2026, 13438.00m, new DateTime(2026, 1, 1)),
+                new AnnualChargeByYear(competentAuthorityId, 2026, 13948.13m, new DateTime(2026, 4, 1)),
                 new AnnualChargeByYear(competentAuthorityId, 2027, 13948.13m, new DateTime(2026, 4, 1))
             };
 
@@ -214,8 +237,9 @@
                 Assert.Equal(12500.00m, result);
             }
 
+            // 2026 should return the uplifted fee since today (April 2026) is past the effective date
             var result2026 = await dataAccess.GetAnnualChargeForComplianceYear(competentAuthorityId, 2026);
-            Assert.Equal(13438.00m, result2026);
+            Assert.Equal(13948.13m, result2026);
 
             var result2027 = await dataAccess.GetAnnualChargeForComplianceYear(competentAuthorityId, 2027);
             Assert.Equal(13948.13m, result2027);

--- a/src/EA.Weee.RequestHandlers.Tests.Unit/Scheme/MemberRegistration/AnnualChargeDataAccessTests.cs
+++ b/src/EA.Weee.RequestHandlers.Tests.Unit/Scheme/MemberRegistration/AnnualChargeDataAccessTests.cs
@@ -64,6 +64,26 @@
         }
 
         [Fact]
+        public async Task GetAnnualChargeForComplianceYear_ReturnsUpliftedCharge_For2027()
+        {
+            // Arrange - 3.8% inflation uplift from £13,438 to £13,948.13 effective from 1st April 2026
+            var competentAuthorityId = Guid.NewGuid();
+            var annualCharges = new List<AnnualChargeByYear>
+            {
+                new AnnualChargeByYear(competentAuthorityId, 2027, 13948.13m, new DateTime(2026, 4, 1))
+            };
+
+            var dbSet = helper.GetAsyncEnabledDbSet(annualCharges);
+            A.CallTo(() => context.AnnualChargesByYear).Returns(dbSet);
+
+            // Act
+            var result = await dataAccess.GetAnnualChargeForComplianceYear(competentAuthorityId, 2027);
+
+            // Assert
+            Assert.Equal(13948.13m, result);
+        }
+
+        [Fact]
         public async Task GetAnnualChargeForComplianceYear_MultipleRecords_ReturnsLatestEffectiveFrom()
         {
             // Arrange
@@ -180,7 +200,8 @@
                 new AnnualChargeByYear(competentAuthorityId, 2023, 12500.00m, new DateTime(2023, 1, 1)),
                 new AnnualChargeByYear(competentAuthorityId, 2024, 12500.00m, new DateTime(2024, 1, 1)),
                 new AnnualChargeByYear(competentAuthorityId, 2025, 12500.00m, new DateTime(2025, 1, 1)),
-                new AnnualChargeByYear(competentAuthorityId, 2026, 13438.00m, new DateTime(2026, 1, 1))
+                new AnnualChargeByYear(competentAuthorityId, 2026, 13438.00m, new DateTime(2026, 1, 1)),
+                new AnnualChargeByYear(competentAuthorityId, 2027, 13948.13m, new DateTime(2026, 4, 1))
             };
 
             var dbSet = helper.GetAsyncEnabledDbSet(annualCharges);
@@ -195,6 +216,9 @@
 
             var result2026 = await dataAccess.GetAnnualChargeForComplianceYear(competentAuthorityId, 2026);
             Assert.Equal(13438.00m, result2026);
+
+            var result2027 = await dataAccess.GetAnnualChargeForComplianceYear(competentAuthorityId, 2027);
+            Assert.Equal(13948.13m, result2027);
         }
     }
 }

--- a/src/EA.Weee.RequestHandlers.Tests.Unit/Scheme/MemberRegistration/TotalChargeCalculatorTests.cs
+++ b/src/EA.Weee.RequestHandlers.Tests.Unit/Scheme/MemberRegistration/TotalChargeCalculatorTests.cs
@@ -135,6 +135,9 @@
         [InlineData("SEPA", 2026)]
         [InlineData("NRW", 2026)]
         [InlineData("NIEA", 2026)]
+        [InlineData("SEPA", 2027)]
+        [InlineData("NRW", 2027)]
+        [InlineData("NIEA", 2027)]
         public void TotalCalculatedCharges_NonEAScheme_DoesNotApplyAnnualCharge(string abbreviation, int complianceYear)
         {
             // Arrange
@@ -249,6 +252,39 @@
 
             // Assert
             Assert.Equal(300, totalCharge); // Only producer charges, annual charge was null
+        }
+
+        [Fact]
+        public void TotalCalculatedCharges_EAScheme_2027_AppliesUpliftedAnnualCharge_13948_13()
+        {
+            // Arrange - Specific test for the 3.8% inflation uplift from April 2026
+            var competentAuthorityId = Guid.NewGuid();
+            var competentAuthority = new UKCompetentAuthority(
+                competentAuthorityId,
+                "Environment Agency",
+                "EA",
+                A.Fake<Country>(),
+                "test@ea.gov.uk",
+                13948.13m);
+
+            var scheme = A.Fake<Scheme>();
+            A.CallTo(() => scheme.CompetentAuthority).Returns(competentAuthority);
+
+            var producerCharges = ProducerCharges();
+            A.CallTo(() => xmlChargeBandCalculator.Calculate(file)).Returns(producerCharges);
+            A.CallTo(() => annualChargeDataAccess.GetAnnualChargeForComplianceYear(competentAuthorityId, 2027))
+                .Returns(13948.13m);
+
+            totalCharge = 0;
+
+            // Act
+            totalChargeCalculator.TotalCalculatedCharges(file, scheme, 2027, true, ref totalCharge);
+
+            // Assert
+            Assert.Equal(300 + 13948.13m, totalCharge);
+            Assert.Equal(14248.13m, totalCharge);
+            A.CallTo(() => annualChargeDataAccess.GetAnnualChargeForComplianceYear(competentAuthorityId, 2027))
+                .MustHaveHappenedOnceExactly();
         }
 
         [Fact]

--- a/src/EA.Weee.RequestHandlers/Scheme/MemberRegistration/AnnualChargeDataAccess.cs
+++ b/src/EA.Weee.RequestHandlers/Scheme/MemberRegistration/AnnualChargeDataAccess.cs
@@ -3,6 +3,7 @@
     using EA.Weee.DataAccess;
     using System;
     using System.Data.Entity;
+    using System.Data.Entity.Core.Common.CommandTrees.ExpressionBuilder;
     using System.Linq;
     using System.Threading.Tasks;
 
@@ -16,10 +17,13 @@
         }
 
         public async Task<decimal?> GetAnnualChargeForComplianceYear(Guid competentAuthorityId, int complianceYear)
-        {     
+        {
+            var now = DateTime.UtcNow;
+
             var annualCharge = await context.AnnualChargesByYear
                 .Where(a => a.CompetentAuthorityId == competentAuthorityId)
                 .Where(a => a.ComplianceYear == complianceYear)
+                .Where(a => a.EffectiveFrom == null || a.EffectiveFrom <= now)
                 .OrderByDescending(a => a.EffectiveFrom)
                 .FirstOrDefaultAsync();
 


### PR DESCRIPTION
Fixes from the bug that Matthew has raised during the demo last week.

When a submission compliance year is 2027 it doesnt return the correct figure for the following year. 