### PR TITLE
Update annual charge logic to support compliance year values

### DIFF
--- a/src/EA.Weee.Database/scripts/Everytime/0004-InsertCompetentAuthorityData.sql
+++ b/src/EA.Weee.Database/scripts/Everytime/0004-InsertCompetentAuthorityData.sql
@@ -11,7 +11,7 @@ AnnualChargeAmount DECIMAL(18,2) NOT NULL)
 
 INSERT INTO @tblTempCompetentAuthorityTable([Id], [Name], [Abbreviation], [CountryId], [Email], AnnualChargeAmount)
 VALUES
-('A3C2D0DD-53A1-4F6A-99D0-1CCFC87611A8', 'Environment Agency', 'EA', '184E1785-26B4-4AE4-80D3-AE319B103ACB', 'ea@b.c', 12500.00),
+('A3C2D0DD-53A1-4F6A-99D0-1CCFC87611A8', 'Environment Agency', 'EA', '184E1785-26B4-4AE4-80D3-AE319B103ACB', 'ea@b.c', 13948.13),
 ('78F37814-364B-4FAE-BEB5-DB0439CBF177', 'Scottish Environment Protection Agency', 'SEPA', '4209EE95-0882-42F2-9A5D-355B4D89EF30', 'sepa@b.c', 0),
 ('4EEE5942-01B2-4A4D-855A-34DEE1BBBF26', 'Northern Ireland Environment Agency', 'NIEA', '7BFB8717-4226-40F3-BC51-B16FDF42550C', 'niea@b.c', 0),
 ('44C2F368-AA66-48F0-BBC9-A0ED34AD0951', 'Natural Resources Wales', 'NRW', 'DB83F5AB-E745-49CF-B2CA-23FE391B67A8', 'nrw@b.c', 0);

--- a/src/EA.Weee.RequestHandlers.Tests.Unit/Charges/IssuePendingCharges/BySchemeTransactionFileGeneratorTests.cs
+++ b/src/EA.Weee.RequestHandlers.Tests.Unit/Charges/IssuePendingCharges/BySchemeTransactionFileGeneratorTests.cs
@@ -9,6 +9,7 @@
     using Ibis;
     using Prsd.Core;
     using RequestHandlers.Charges.IssuePendingCharges;
+    using RequestHandlers.Scheme.MemberRegistration;
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
@@ -18,13 +19,15 @@
     public class BySchemeTransactionFileGeneratorTests
     {
         private readonly ITransactionReferenceGenerator transactionReferenceGenerator;
+        private readonly IAnnualChargeDataAccess annualChargeDataAccess;
         private readonly BySchemeTransactionFileGenerator generator;
 
         public BySchemeTransactionFileGeneratorTests()
         {
             transactionReferenceGenerator = A.Fake<ITransactionReferenceGenerator>();
+            annualChargeDataAccess = A.Fake<IAnnualChargeDataAccess>();
 
-            generator = new BySchemeTransactionFileGenerator(transactionReferenceGenerator);
+            generator = new BySchemeTransactionFileGenerator(transactionReferenceGenerator, annualChargeDataAccess);
         }
 
         /// <summary>
@@ -385,15 +388,24 @@
         public async Task CreateTransactionFile_GivenMemberUploadContainsAnnualChargeAndSchemeHasAnnualChargeAmount_DescriptionShouldContainAnnualCharge()
         {
             var organisation = A.Fake<Organisation>();
-            var authority = A.Fake<UKCompetentAuthority>();
             var scheme = A.Fake<Scheme>();
+            var competentAuthorityId = Guid.NewGuid();
+            var complianceYear = 2026;
+
+            var authority = new UKCompetentAuthority(
+                competentAuthorityId,
+                "Environment Agency",
+                "EA",
+                A.Dummy<Country>(),
+                "ea@b.c",
+                12500m);
 
             var memberUpload = new MemberUpload(
                 A.Dummy<Guid>(),
                 A.Dummy<string>(),
                 A.Dummy<List<MemberUploadError>>(),
                 123.45m,
-                A.Dummy<int>(),
+                complianceYear,
                 scheme,
                 A.Dummy<string>(),
                 A.Dummy<string>(),
@@ -403,11 +415,12 @@
             memberUpload.Submit(A.Dummy<User>());
             SystemTime.Unfreeze();
 
-            A.CallTo(() => authority.AnnualChargeAmount).Returns(12500);
             A.CallTo(() => scheme.IbisCustomerReference).Returns("WEE00000002");
             A.CallTo(() => scheme.Organisation).Returns(organisation);
             A.CallTo(() => scheme.CompetentAuthority).Returns(authority);
             A.CallTo(() => transactionReferenceGenerator.GetNextTransactionReferenceAsync()).Returns("WEE800001H");
+            A.CallTo(() => annualChargeDataAccess.GetAnnualChargeForComplianceYear(competentAuthorityId, complianceYear))
+                .Returns(13948.13m);
 
             var memberUploads = new List<MemberUpload>() { memberUpload };
 
@@ -415,22 +428,31 @@
 
             var result = await generator.CreateAsync(0, invoiceRun);
 
-            Assert.Equal("Charge for producer registration submission made on 01 Jan 2019 and the 12,500.00 annual charge.", result.IbisFile.Invoices[0].LineItems[0].Description);
+            Assert.Equal("Charge for producer registration submission made on 01 Jan 2019 and the 13,948.13 annual charge.", result.IbisFile.Invoices[0].LineItems[0].Description);
         }
 
         [Fact]
         public async Task CreateTransactionFile_GivenMemberUploadSchemeHasZeroAnnualChargeAmount_DescriptionShouldNotContainAnnualCharge()
         {
             var organisation = A.Fake<Organisation>();
-            var authority = A.Fake<UKCompetentAuthority>();
             var scheme = A.Fake<Scheme>();
+            var competentAuthorityId = Guid.NewGuid();
+            var complianceYear = 2026;
+
+            var authority = new UKCompetentAuthority(
+                competentAuthorityId,
+                "Environment Agency",
+                "EA",
+                A.Dummy<Country>(),
+                "ea@b.c",
+                0m);
 
             var memberUpload = new MemberUpload(
                 A.Dummy<Guid>(),
                 A.Dummy<string>(),
                 A.Dummy<List<MemberUploadError>>(),
                 123.45m,
-                A.Dummy<int>(),
+                complianceYear,
                 scheme,
                 A.Dummy<string>(),
                 A.Dummy<string>(),
@@ -440,11 +462,12 @@
             memberUpload.Submit(A.Dummy<User>());
             SystemTime.Unfreeze();
 
-            A.CallTo(() => authority.AnnualChargeAmount).Returns(0);
             A.CallTo(() => scheme.IbisCustomerReference).Returns("WEE00000002");
             A.CallTo(() => scheme.Organisation).Returns(organisation);
             A.CallTo(() => scheme.CompetentAuthority).Returns(authority);
             A.CallTo(() => transactionReferenceGenerator.GetNextTransactionReferenceAsync()).Returns("WEE800001H");
+            A.CallTo(() => annualChargeDataAccess.GetAnnualChargeForComplianceYear(competentAuthorityId, complianceYear))
+                .Returns(0m);
 
             var memberUploads = new List<MemberUpload>() { memberUpload };
 
@@ -477,7 +500,6 @@
             memberUpload.Submit(A.Dummy<User>());
             SystemTime.Unfreeze();
 
-            A.CallTo(() => authority.AnnualChargeAmount).Returns(0);
             A.CallTo(() => scheme.IbisCustomerReference).Returns("WEE00000002");
             A.CallTo(() => scheme.Organisation).Returns(organisation);
             A.CallTo(() => scheme.CompetentAuthority).Returns(authority);

--- a/src/EA.Weee.RequestHandlers/Charges/IssuePendingCharges/BySchemeTransactionFileGenerator.cs
+++ b/src/EA.Weee.RequestHandlers/Charges/IssuePendingCharges/BySchemeTransactionFileGenerator.cs
@@ -3,6 +3,7 @@
     using Domain.Charges;
     using EA.Weee.Domain.Scheme;
     using EA.Weee.Ibis;
+    using EA.Weee.RequestHandlers.Scheme.MemberRegistration;
     using Errors;
     using System;
     using System.Collections.Generic;
@@ -17,11 +18,15 @@
     public class BySchemeTransactionFileGenerator : IIbisTransactionFileGenerator
     {
         private readonly ITransactionReferenceGenerator transactionReferenceGenerator;
+        private readonly IAnnualChargeDataAccess annualChargeDataAccess;
         private const string CommonMessageString = "Charge for producer registration submission made on {0:dd MMM yyyy}";
 
-        public BySchemeTransactionFileGenerator(ITransactionReferenceGenerator transactionReferenceGenerator)
+        public BySchemeTransactionFileGenerator(
+            ITransactionReferenceGenerator transactionReferenceGenerator,
+            IAnnualChargeDataAccess annualChargeDataAccess)
         {
             this.transactionReferenceGenerator = transactionReferenceGenerator;
+            this.annualChargeDataAccess = annualChargeDataAccess;
         }
 
         public async Task<IbisFileGeneratorResult<TransactionFile>> CreateAsync(ulong fileID, InvoiceRun invoiceRun)
@@ -39,13 +44,19 @@
                 foreach (MemberUpload memberUpload in group)
                 {
                     var submittedDate = memberUpload.SubmittedDate.Value;
-                    var competantAuthorityAnnualChargeAmount = memberUpload.Scheme.CompetentAuthority.AnnualChargeAmount;
 
                     var description = string.Format("{0}.", CommonMessage(submittedDate));
 
-                    if (memberUpload.HasAnnualCharge && competantAuthorityAnnualChargeAmount > 0)
+                    if (memberUpload.HasAnnualCharge)
                     {
-                        description = string.Format("{0} and the {1} annual charge.", CommonMessage(submittedDate), competantAuthorityAnnualChargeAmount.Value.ToString("#,##0.00"));
+                        var annualChargeAmount = await annualChargeDataAccess.GetAnnualChargeForComplianceYear(
+                            memberUpload.Scheme.CompetentAuthority.Id,
+                            memberUpload.ComplianceYear.Value);
+
+                        if (annualChargeAmount.HasValue && annualChargeAmount.Value > 0)
+                        {
+                            description = string.Format("{0} and the {1} annual charge.", CommonMessage(submittedDate), annualChargeAmount.Value.ToString("#,##0.00"));
+                        }
                     }
 
                     try


### PR DESCRIPTION
Updated Environment Agency annual charge seed data to 13,948.13. Refactored BySchemeTransactionFileGenerator to use IAnnualChargeDataAccess for retrieving annual charge amounts by compliance year, enabling support for year-specific values instead of a static property. Adjusted invoice line item descriptions accordingly.