### PR TITLE
Refactor POST Index to redirect with filter parameters

### DIFF
--- a/src/EA.Weee.Core/EA.Weee.Core.csproj
+++ b/src/EA.Weee.Core/EA.Weee.Core.csproj
@@ -325,6 +325,7 @@
     <Compile Include="Helpers\IJsonSerialiser.cs" />
     <Compile Include="Helpers\JsonSerializer.cs" />
     <Compile Include="Helpers\ReflectionExtensions.cs" />
+    <Compile Include="Helpers\RouteValueBuilder.cs" />
     <Compile Include="Helpers\WindowHelper.cs" />
     <Compile Include="Organisations\IProducerSubmissionViewModel.cs" />
     <Compile Include="Organisations\NotRequiredPartnerModel.cs" />

--- a/src/EA.Weee.Core/Helpers/RouteValueBuilder.cs
+++ b/src/EA.Weee.Core/Helpers/RouteValueBuilder.cs
@@ -1,0 +1,45 @@
+﻿namespace EA.Weee.Core.Helpers
+{
+    using System;
+    using System.Web.Routing;
+
+    public class RouteValueBuilder
+    {
+        private readonly RouteValueDictionary values = new RouteValueDictionary();
+
+        public RouteValueBuilder Add(string key, object value)
+        {
+            values[key] = value;
+            return this;
+        }
+
+        public RouteValueBuilder AddIf(bool condition, string key, object value)
+        {
+            if (condition)
+            {
+                values[key] = value;
+            }
+            return this;
+        }
+
+        public RouteValueBuilder AddIfNotEmpty(string value, string key)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                values[key] = value;
+            }
+            return this;
+        }
+
+        public RouteValueBuilder AddIfHasValue<T>(T? value, string key, Func<T, object> transform = null) where T : struct
+        {
+            if (value.HasValue)
+            {
+                values[key] = transform != null ? transform(value.Value) : value.Value;
+            }
+            return this;
+        }
+
+        public RouteValueDictionary Build() => values;
+    }
+}

--- a/src/EA.Weee.Web.Tests.Unit/Areas/Scheme/Controllers/ManageEvidenceNotesControllerReviewEvidenceNoteTests.cs
+++ b/src/EA.Weee.Web.Tests.Unit/Areas/Scheme/Controllers/ManageEvidenceNotesControllerReviewEvidenceNoteTests.cs
@@ -604,7 +604,7 @@
             A.CallTo(() => WeeeClient.SendAsync(A<string>._, A<GetApiUtcDate>._)).Returns(currentDate);
 
             //act
-            await ManageEvidenceController.Index(RecipientId, "review-submitted-evidence", model, pageNumber);
+            ManageEvidenceController.Index(RecipientId, "review-submitted-evidence", model, pageNumber);
 
             //assert
             A.CallTo(() => Mapper.Map<ReviewSubmittedManageEvidenceNotesSchemeViewModel>(

--- a/src/EA.Weee.Web.Tests.Unit/Areas/Scheme/Controllers/ManageEvidenceNotesControllerTests.cs
+++ b/src/EA.Weee.Web.Tests.Unit/Areas/Scheme/Controllers/ManageEvidenceNotesControllerTests.cs
@@ -246,7 +246,7 @@
                     .With(e => e.SelectedComplianceYear, complianceYear).Create();
 
             //act
-            await ManageEvidenceController.Index(OrganisationId, tab, model, 1);
+            ManageEvidenceController.Index(OrganisationId, tab, model, 1);
 
             A.CallTo(() => Mapper.Map<ManageEvidenceNoteViewModel>(A<ManageEvidenceNoteTransfer>
                     .That.Matches(m =>
@@ -384,7 +384,7 @@
             const int pageNumber = 10;
 
             //act
-            await ManageEvidenceController.Index(OrganisationId, "review-submitted-evidence", null, pageNumber);
+            ManageEvidenceController.Index(OrganisationId, "review-submitted-evidence", null, pageNumber);
 
             //assert
             A.CallTo(() => WeeeClient.SendAsync(A<string>._, A<GetEvidenceNotesByOrganisationRequest>.That.Matches(
@@ -488,7 +488,7 @@
             const int pageNumber = 10;
 
             //act
-            await ManageEvidenceController.Index(OrganisationId, "review-submitted-evidence", null, pageNumber);
+            ManageEvidenceController.Index(OrganisationId, "review-submitted-evidence", null, pageNumber);
 
             //assert
             A.CallTo(() => Mapper.Map<ReviewSubmittedManageEvidenceNotesSchemeViewModel>(
@@ -566,7 +566,7 @@
             const int pageNumber = 10;
 
             //act
-            await ManageEvidenceController.Index(OrganisationId, ManageEvidenceNotesDisplayOptions.ViewAndTransferEvidence.ToDisplayString(), null, pageNumber);
+            ManageEvidenceController.Index(OrganisationId, ManageEvidenceNotesDisplayOptions.ViewAndTransferEvidence.ToDisplayString(), null, pageNumber);
 
             //assert
             A.CallTo(() => Mapper.Map<SchemeViewAndTransferManageEvidenceSchemeViewModel>(
@@ -631,7 +631,7 @@
             A.CallTo(() => WeeeClient.SendAsync(A<string>._, A<GetApiUtcDate>._)).Returns(currentDate);
 
             //act
-            await ManageEvidenceController.Index(OrganisationId, tab, manageEvidenceNoteViewModel, 1);
+            ManageEvidenceController.Index(OrganisationId, tab, manageEvidenceNoteViewModel, 1);
 
             //assert
             A.CallTo(() => WeeeClient.SendAsync(A<string>._, A<GetEvidenceNotesByOrganisationRequest>.That.Matches(
@@ -689,7 +689,7 @@
             const int pageNumber = 10;
 
             //act
-            await ManageEvidenceController.Index(OrganisationId, ManageEvidenceNotesDisplayOptions.ViewAndTransferEvidence.ToDisplayString(), null, pageNumber);
+            ManageEvidenceController.Index(OrganisationId, ManageEvidenceNotesDisplayOptions.ViewAndTransferEvidence.ToDisplayString(), null, pageNumber);
 
             //assert
             A.CallTo(() => WeeeClient.SendAsync(A<string>._, A<GetEvidenceNotesByOrganisationRequest>
@@ -865,7 +865,7 @@
             const int pageSize = 10;
 
             //act
-            await ManageEvidenceController.Index(OrganisationId, "outgoing-transfers", null, pageNumber);
+            ManageEvidenceController.Index(OrganisationId, "outgoing-transfers", null, pageNumber);
 
             //assert
             A.CallTo(() => WeeeClient.SendAsync(A<string>._, A<GetEvidenceNotesByOrganisationRequest>
@@ -994,7 +994,7 @@
             const int pageSize = 10;
 
             //act
-            await ManageEvidenceController.Index(OrganisationId, "outgoing-transfers", model, pageNumber);
+            ManageEvidenceController.Index(OrganisationId, "outgoing-transfers", model, pageNumber);
 
             //assert
             A.CallTo(() => Mapper.Map<TransferredOutEvidenceNotesSchemeViewModel>(
@@ -1069,7 +1069,7 @@
             A.CallTo(() => WeeeClient.SendAsync(A<string>._, A<GetApiUtcDate>._)).Returns(currentDate);
 
             //act
-            await ManageEvidenceController.Index(OrganisationId, "view-and-transfer-evidence", model, pageNumber);
+            ManageEvidenceController.Index(OrganisationId, "view-and-transfer-evidence", model, pageNumber);
 
             //assert
             A.CallTo(() => Mapper.Map<SchemeViewAndTransferManageEvidenceSchemeViewModel>(
@@ -1203,7 +1203,7 @@
             A.CallTo(() => WeeeClient.SendAsync(A<string>._, A<GetApiUtcDate>._)).Returns(currentDate);
 
             // act
-            await ManageEvidenceController.Index(OrganisationId, tab, model, 1);
+            ManageEvidenceController.Index(OrganisationId, tab, model, 1);
 
             // assert
             A.CallTo(() => WeeeClient.SendAsync(A<string>._, A<GetObligationSummaryRequest>.That.Matches(
@@ -1235,7 +1235,7 @@
             A.CallTo(() => WeeeClient.SendAsync(A<string>._, A<GetApiUtcDate>._)).Returns(currentDate);
 
             // act
-            await ManageEvidenceController.Index(OrganisationId, tab, model, 1);
+            ManageEvidenceController.Index(OrganisationId, tab, model, 1);
 
             // assert
             A.CallTo(() => WeeeClient.SendAsync(A<string>._, A<GetObligationSummaryRequest>.That.Matches(
@@ -1302,7 +1302,7 @@
             A.CallTo(() => WeeeClient.SendAsync(A<string>._, A<GetApiUtcDate>._)).Returns(currentDate);
 
             // act
-            await ManageEvidenceController.Index(OrganisationId, tab, model, 1);
+            ManageEvidenceController.Index(OrganisationId, tab, model, 1);
 
             // assert
             A.CallTo(() => Mapper.Map<SummaryEvidenceViewModel>(

--- a/src/EA.Weee.Web/Areas/Scheme/Controllers/ManageEvidenceNotesController.cs
+++ b/src/EA.Weee.Web/Areas/Scheme/Controllers/ManageEvidenceNotesController.cs
@@ -97,64 +97,39 @@
 
         private static RouteValueDictionary BuildFilterRouteValues(Guid pcsId, string tab, ManageEvidenceNoteViewModel model, int page)
         {
-            var routeValues = new RouteValueDictionary
-             {
-                 { "pcsId", pcsId },
-                 { "tab", tab },
-                 { "page", page }
-             };
+            var builder = new Core.Helpers.RouteValueBuilder()
+                                .Add("pcsId", pcsId)
+                                .Add("tab", tab)
+                                .Add("page", page);
 
             if (model == null)
             {
-                return routeValues;
+                return builder.Build();
             }
 
-            if (model.SelectedComplianceYear > 0)
-            {
-                routeValues["selectedComplianceYear"] = model.SelectedComplianceYear;
-            }
+            builder
+                .AddIf(model.SelectedComplianceYear > 0,
+                    "selectedComplianceYear", model.SelectedComplianceYear)
 
-            if (!string.IsNullOrWhiteSpace(model.FilterViewModel?.SearchRef))
-            {
-                routeValues["searchRef"] = model.FilterViewModel.SearchRef;
-            }
+                .AddIfNotEmpty(model.FilterViewModel?.SearchRef,
+                    "searchRef")
 
-            if (model.SubmittedDatesFilterViewModel?.StartDate.HasValue == true)
-            {
-                routeValues["startDate"] = model.SubmittedDatesFilterViewModel.StartDate.Value.ToString("dd/MM/yyyy");
-            }
+                .AddIfHasValue(model.SubmittedDatesFilterViewModel?.StartDate,
+                    "startDate", d => d.ToString("dd/MM/yyyy"))
 
-            if (model.SubmittedDatesFilterViewModel?.EndDate.HasValue == true)
-            {
-                routeValues["endDate"] = model.SubmittedDatesFilterViewModel.EndDate.Value.ToString("dd/MM/yyyy");
-            }
+                .AddIfHasValue(model.SubmittedDatesFilterViewModel?.EndDate,
+                    "endDate", d => d.ToString("dd/MM/yyyy"));
 
-            if (model.RecipientWasteStatusFilterViewModel?.ReceivedId.HasValue == true)
-            {
-                routeValues["receivedId"] = model.RecipientWasteStatusFilterViewModel.ReceivedId.Value;
-            }
+            var waste = model.RecipientWasteStatusFilterViewModel;
 
-            if (model.RecipientWasteStatusFilterViewModel?.WasteTypeValue.HasValue == true)
-            {
-                routeValues["wasteTypeValue"] = (int)model.RecipientWasteStatusFilterViewModel.WasteTypeValue.Value;
-            }
+            builder
+                .AddIfHasValue(waste?.ReceivedId, "receivedId")
+                .AddIfHasValue(waste?.WasteTypeValue, "wasteTypeValue", wasteType => (int)wasteType)
+                .AddIfHasValue(waste?.EvidenceNoteTypeValue, "evidenceNoteTypeValue", evidenceNoteType => (int)evidenceNoteType)
+                .AddIfHasValue(waste?.NoteStatusValue, "noteStatusValue", noteStatus => (int)noteStatus)
+                .AddIfHasValue(waste?.SubmittedBy, "submittedBy");
 
-            if (model.RecipientWasteStatusFilterViewModel?.EvidenceNoteTypeValue.HasValue == true)
-            {
-                routeValues["evidenceNoteTypeValue"] = (int)model.RecipientWasteStatusFilterViewModel.EvidenceNoteTypeValue.Value;
-            }
-
-            if (model.RecipientWasteStatusFilterViewModel?.NoteStatusValue.HasValue == true)
-            {
-                routeValues["noteStatusValue"] = (int)model.RecipientWasteStatusFilterViewModel.NoteStatusValue.Value;
-            }
-
-            if (model.RecipientWasteStatusFilterViewModel?.SubmittedBy.HasValue == true)
-            {
-                routeValues["submittedBy"] = model.RecipientWasteStatusFilterViewModel.SubmittedBy.Value;
-            }
-
-            return routeValues;
+            return builder.Build();
         }
 
         private async Task<ActionResult> ProcessManageEvidenceNotes(Guid pcsId, string tab, ManageEvidenceNoteViewModel manageEvidenceNoteViewModel, int page)

--- a/src/EA.Weee.Web/Areas/Scheme/Controllers/ManageEvidenceNotesController.cs
+++ b/src/EA.Weee.Web/Areas/Scheme/Controllers/ManageEvidenceNotesController.cs
@@ -27,6 +27,7 @@
     using System.Text;
     using System.Threading.Tasks;
     using System.Web.Mvc;
+    using System.Web.Routing;
     using Web.ViewModels.Shared;
     using Web.ViewModels.Shared.Mapping;
     using Weee.Requests.Shared;
@@ -89,9 +90,71 @@
 
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<ActionResult> Index(Guid pcsId, string tab = null, ManageEvidenceNoteViewModel manageEvidenceNoteViewModel = null, int page = 1)
+        public ActionResult Index(Guid pcsId, string tab = null, ManageEvidenceNoteViewModel manageEvidenceNoteViewModel = null, int page = 1)
         {
-            return await ProcessManageEvidenceNotes(pcsId, tab, manageEvidenceNoteViewModel, page);
+            return RedirectToAction("Index", BuildFilterRouteValues(pcsId, tab, manageEvidenceNoteViewModel, page));
+        }
+
+        private static RouteValueDictionary BuildFilterRouteValues(Guid pcsId, string tab, ManageEvidenceNoteViewModel model, int page)
+        {
+            var routeValues = new RouteValueDictionary
+             {
+                 { "pcsId", pcsId },
+                 { "tab", tab },
+                 { "page", page }
+             };
+
+            if (model == null)
+            {
+                return routeValues;
+            }
+
+            if (model.SelectedComplianceYear > 0)
+            {
+                routeValues["selectedComplianceYear"] = model.SelectedComplianceYear;
+            }
+
+            if (!string.IsNullOrWhiteSpace(model.FilterViewModel?.SearchRef))
+            {
+                routeValues["searchRef"] = model.FilterViewModel.SearchRef;
+            }
+
+            if (model.SubmittedDatesFilterViewModel?.StartDate.HasValue == true)
+            {
+                routeValues["startDate"] = model.SubmittedDatesFilterViewModel.StartDate.Value.ToString("dd/MM/yyyy");
+            }
+
+            if (model.SubmittedDatesFilterViewModel?.EndDate.HasValue == true)
+            {
+                routeValues["endDate"] = model.SubmittedDatesFilterViewModel.EndDate.Value.ToString("dd/MM/yyyy");
+            }
+
+            if (model.RecipientWasteStatusFilterViewModel?.ReceivedId.HasValue == true)
+            {
+                routeValues["receivedId"] = model.RecipientWasteStatusFilterViewModel.ReceivedId.Value;
+            }
+
+            if (model.RecipientWasteStatusFilterViewModel?.WasteTypeValue.HasValue == true)
+            {
+                routeValues["wasteTypeValue"] = (int)model.RecipientWasteStatusFilterViewModel.WasteTypeValue.Value;
+            }
+
+            if (model.RecipientWasteStatusFilterViewModel?.EvidenceNoteTypeValue.HasValue == true)
+            {
+                routeValues["evidenceNoteTypeValue"] = (int)model.RecipientWasteStatusFilterViewModel.EvidenceNoteTypeValue.Value;
+            }
+
+            if (model.RecipientWasteStatusFilterViewModel?.NoteStatusValue.HasValue == true)
+            {
+                routeValues["noteStatusValue"] = (int)model.RecipientWasteStatusFilterViewModel.NoteStatusValue.Value;
+            }
+
+            if (model.RecipientWasteStatusFilterViewModel?.SubmittedBy.HasValue == true)
+            {
+                routeValues["submittedBy"] = model.RecipientWasteStatusFilterViewModel.SubmittedBy.Value;
+            }
+
+            return routeValues;
         }
 
         private async Task<ActionResult> ProcessManageEvidenceNotes(Guid pcsId, string tab, ManageEvidenceNoteViewModel manageEvidenceNoteViewModel, int page)


### PR DESCRIPTION
Update ManageEvidenceNotesController so the POST Index action redirects to the GET Index action, preserving all filter and paging parameters in the URL. Introduce BuildFilterRouteValues to construct route values from the view model, supporting the Post/Redirect/Get pattern and improving usability by making filter states shareable and bookmarkable.