### PR TITLE
Preserve filter state in Scheme evidence/transfer note views

### DIFF
--- a/src/EA.Weee.Web/Areas/Scheme/Controllers/ManageEvidenceNotesController.cs
+++ b/src/EA.Weee.Web/Areas/Scheme/Controllers/ManageEvidenceNotesController.cs
@@ -60,7 +60,7 @@
 
         [HttpGet]
         [NoCacheFilter]
-        public async Task<ActionResult> Index(Guid pcsId, string tab = null, int? selectedComplianceYear = null, int? page = 1, DateTime? startDate = null, DateTime? endDate = null, Guid? receivedId = null,
+        public async Task<ActionResult> Index(Guid pcsId, string tab = null, int? selectedComplianceYear = null, int? page = 1, string startDate = null, string endDate = null, Guid? receivedId = null,
                                               int? wasteTypeValue = null, int? evidenceNoteTypeValue = null, string searchRef = null, int? noteStatusValue = null, Guid? submittedBy = null)
         {
             var manageEvidenceNoteViewModel = new ManageEvidenceNoteViewModel()
@@ -80,12 +80,29 @@
                 },
                 SubmittedDatesFilterViewModel = new SubmittedDatesFilterViewModel()
                 {
-                    StartDate = startDate,
-                    EndDate = endDate
+                    StartDate = ParseDate(startDate),
+                    EndDate = ParseDate(endDate)
                 }
             };
             page = page ?? 1;
             return await ProcessManageEvidenceNotes(pcsId, tab, manageEvidenceNoteViewModel, page.Value);
+        }
+
+        private static DateTime? ParseDate(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return null;
+            }
+
+            if (DateTime.TryParseExact(value, new[] { "dd-MM-yyyy", "dd/MM/yyyy" },
+                System.Globalization.CultureInfo.InvariantCulture,
+                System.Globalization.DateTimeStyles.None, out var result))
+            {
+                return result;
+            }
+
+            return null;
         }
 
         [HttpPost]
@@ -115,10 +132,10 @@
                     "searchRef")
 
                 .AddIfHasValue(model.SubmittedDatesFilterViewModel?.StartDate,
-                    "startDate", d => d.ToString("dd/MM/yyyy"))
+                    "startDate", d => d.ToString("dd-MM-yyyy"))
 
                 .AddIfHasValue(model.SubmittedDatesFilterViewModel?.EndDate,
-                    "endDate", d => d.ToString("dd/MM/yyyy"));
+                    "endDate", d => d.ToString("dd-MM-yyyy"));
 
             var waste = model.RecipientWasteStatusFilterViewModel;
 
@@ -258,8 +275,8 @@
 
                 var submittedDatesFilterViewModel = mapper.Map<SubmittedDatesFilterViewModel>(new SubmittedDateFilterBase(noteViewModel?.SubmittedDatesFilterViewModel.StartDate, noteViewModel?.SubmittedDatesFilterViewModel.EndDate));
                 var recipientWasteStatusViewModel = mapper.Map<RecipientWasteStatusFilterViewModel>(new RecipientWasteStatusFilterBase(null, null, noteViewModel?.RecipientWasteStatusFilterViewModel.WasteTypeValue,
-                                                                                                                                       noteViewModel?.RecipientWasteStatusFilterViewModel.NoteStatusValue, noteViewModel?.RecipientWasteStatusFilterViewModel.SubmittedBy,
-                                                                                                                                       submittedByFilterList, noteViewModel?.RecipientWasteStatusFilterViewModel.EvidenceNoteTypeValue, true, true, defaultNoteStatusList));
+                                                                                                                                        noteViewModel?.RecipientWasteStatusFilterViewModel.NoteStatusValue, noteViewModel?.RecipientWasteStatusFilterViewModel.SubmittedBy,
+                                                                                                                                        submittedByFilterList, noteViewModel?.RecipientWasteStatusFilterViewModel.EvidenceNoteTypeValue, true, true, defaultNoteStatusList));
 
                 var model = mapper.Map<SchemeViewAndTransferManageEvidenceSchemeViewModel>(new SchemeTabViewModelMapTransfer(organisationId, result, scheme, currentDate, selectedComplianceYear, pageNumber, configurationService.CurrentConfiguration.DefaultExternalPagingPageSize));
 
@@ -458,7 +475,7 @@
                 }
 
                 var recipientWasteStatusViewModel = mapper.Map<RecipientWasteStatusFilterViewModel>(new RecipientWasteStatusFilterBase(recipientData, noteViewModel?.RecipientWasteStatusFilterViewModel.ReceivedId, null,
-                                                                                                                                       noteViewModel?.RecipientWasteStatusFilterViewModel.NoteStatusValue, null, null, null, false, false, defaultStatusList));
+                                                                                                                                        noteViewModel?.RecipientWasteStatusFilterViewModel.NoteStatusValue, null, null, null, false, false, defaultStatusList));
                 var model = mapper.Map<TransferredOutEvidenceNotesSchemeViewModel>(new SchemeTabViewModelMapTransfer(organisationId, result, scheme, currentDate, selectedComplianceYear, pageNumber, configurationService.CurrentConfiguration.DefaultExternalPagingPageSize));
                 model.ManageEvidenceNoteViewModel = mapper.Map<ManageEvidenceNoteViewModel>(new ManageEvidenceNoteTransfer(organisationId, noteViewModel?.FilterViewModel, recipientWasteStatusViewModel, submittedDatesFilterViewModel, selectedComplianceYear, currentDate));
 
@@ -469,13 +486,25 @@
         [HttpGet]
         [CheckCanApproveNote]
         [NoCacheFilter]
-        public async Task<ActionResult> ReviewEvidenceNote(Guid pcsId, Guid evidenceNoteId, string queryString = null)
-        {
+        public async Task<ActionResult> ReviewEvidenceNote(Guid pcsId, Guid evidenceNoteId, string queryString = null,
+            string return_tab = null, int? return_page = null, int? return_selectedComplianceYear = null,
+            string return_startDate = null, string return_endDate = null, string return_searchRef = null,
+            Guid? return_receivedId = null, int? return_wasteTypeValue = null, int? return_evidenceNoteTypeValue = null,
+            int? return_noteStatusValue = null, Guid? return_submittedBy = null)
+        {   
             using (var client = this.apiClient())
             {
                 await SetBreadcrumb(pcsId);
 
-                ReviewEvidenceNoteViewModel model = await GetNote(pcsId, evidenceNoteId, queryString, client);
+                var returnQueryString = BuildReturnQueryString(
+                    return_tab, return_page, return_selectedComplianceYear,
+                    return_startDate, return_endDate, return_searchRef,
+                    return_receivedId, return_wasteTypeValue, return_evidenceNoteTypeValue,
+                    return_noteStatusValue, return_submittedBy);
+
+                var effectiveQueryString = !string.IsNullOrEmpty(returnQueryString) ? returnQueryString : queryString;
+
+                ReviewEvidenceNoteViewModel model = await GetNote(pcsId, evidenceNoteId, effectiveQueryString, client);
 
                 if (model.ViewEvidenceNoteViewModel.Status != NoteStatus.Submitted)
                 {
@@ -484,6 +513,72 @@
 
                 return View("ReviewEvidenceNote", model);
             }
+        }
+
+        internal static string BuildReturnQueryString(
+            string tab, int? page, int? selectedComplianceYear,
+            string startDate, string endDate, string searchRef,
+            Guid? receivedId, int? wasteTypeValue, int? evidenceNoteTypeValue,
+            int? noteStatusValue, Guid? submittedBy)
+        {
+            var parts = new List<string>();
+
+            if (!string.IsNullOrEmpty(tab))
+            {
+                parts.Add($"tab={Uri.EscapeDataString(tab)}");
+            }
+
+            if (page.HasValue)
+            {
+                parts.Add($"page={page.Value}");
+            }
+
+            if (selectedComplianceYear.HasValue)
+            {
+                parts.Add($"selectedComplianceYear={selectedComplianceYear.Value}");
+            }
+
+            if (!string.IsNullOrEmpty(startDate))
+            {
+                parts.Add($"startDate={Uri.EscapeDataString(startDate)}");
+            }
+
+            if (!string.IsNullOrEmpty(endDate))
+            {
+                parts.Add($"endDate={Uri.EscapeDataString(endDate)}");
+            }
+
+            if (!string.IsNullOrEmpty(searchRef))
+            {
+                parts.Add($"searchRef={Uri.EscapeDataString(searchRef)}");
+            }
+
+            if (receivedId.HasValue)
+            {
+                parts.Add($"receivedId={receivedId.Value}");
+            }
+
+            if (wasteTypeValue.HasValue)
+            {
+                parts.Add($"wasteTypeValue={wasteTypeValue.Value}");
+            }
+
+            if (evidenceNoteTypeValue.HasValue)
+            {
+                parts.Add($"evidenceNoteTypeValue={evidenceNoteTypeValue.Value}");
+            }
+
+            if (noteStatusValue.HasValue)
+            {
+                parts.Add($"noteStatusValue={noteStatusValue.Value}");
+            }
+
+            if (submittedBy.HasValue)
+            {
+                parts.Add($"submittedBy={submittedBy.Value}");
+            }
+
+            return parts.Count > 0 ? string.Join("&", parts) : null;
         }
 
         [HttpPost]
@@ -520,7 +615,11 @@
             string redirectTab = null,
             int page = 1,
             bool openedInNewTab = false,
-            string queryString = null)
+            string queryString = null,
+            string return_tab = null, int? return_page = null, int? return_selectedComplianceYear = null,
+            string return_startDate = null, string return_endDate = null, string return_searchRef = null,
+            Guid? return_receivedId = null, int? return_wasteTypeValue = null, int? return_evidenceNoteTypeValue = null,
+            int? return_noteStatusValue = null, Guid? return_submittedBy = null)
         {
             using (var client = this.apiClient())
             {
@@ -530,12 +629,20 @@
 
                 var result = await client.SendAsync(User.GetAccessToken(), request);
 
+                var returnQueryString = BuildReturnQueryString(
+                    return_tab, return_page, return_selectedComplianceYear,
+                    return_startDate, return_endDate, return_searchRef,
+                    return_receivedId, return_wasteTypeValue, return_evidenceNoteTypeValue,
+                    return_noteStatusValue, return_submittedBy);
+
+                var effectiveQueryString = !string.IsNullOrEmpty(returnQueryString) ? returnQueryString : queryString;
+
                 var model = mapper.Map<ViewEvidenceNoteViewModel>(new ViewEvidenceNoteMapTransfer(result, TempData[ViewDataConstant.EvidenceNoteStatus], false)
                 {
                     SchemeId = pcsId,
                     RedirectTab = redirectTab,
                     OpenedInNewTab = openedInNewTab,
-                    QueryString = queryString
+                    QueryString = effectiveQueryString
                 });
 
                 ViewBag.Page = page;
@@ -553,7 +660,6 @@
                 GetObligationSummaryRequest request = null;
                 if (scheme.IsBalancingScheme)
                 {
-                    // PBS do not have a scheme id - we send a null to the Stored Proc which will use organisation id instead
                     request = new GetObligationSummaryRequest(null, pcsId, selectedComplianceYear);
 
                     var evidenceSummaryData = await client.SendAsync(User.GetAccessToken(), request);
@@ -566,7 +672,6 @@
                     return View("SummaryEvidencePBS", pbsSummaryModel);
                 }
 
-                // used by Scheme users
                 request = new GetObligationSummaryRequest(scheme.SchemeId, pcsId, selectedComplianceYear);
 
                 var obligationEvidenceSummaryData = await client.SendAsync(User.GetAccessToken(), request);

--- a/src/EA.Weee.Web/Areas/Scheme/Controllers/TransferEvidenceController.cs
+++ b/src/EA.Weee.Web/Areas/Scheme/Controllers/TransferEvidenceController.cs
@@ -258,7 +258,11 @@
         [HttpGet]
         [NoCacheFilter]
         public async Task<ActionResult> TransferredEvidence(Guid pcsId, Guid evidenceNoteId, string redirectTab, string linkType = "", int page = 1,
-            bool openedInNewTab = false, string queryString = null)
+            bool openedInNewTab = false, string queryString = null,
+            string return_tab = null, int? return_page = null, int? return_selectedComplianceYear = null,
+            string return_startDate = null, string return_endDate = null, string return_searchRef = null,
+            Guid? return_receivedId = null, int? return_wasteTypeValue = null, int? return_evidenceNoteTypeValue = null,
+            int? return_noteStatusValue = null, Guid? return_submittedBy = null)
         {
             await SetBreadcrumb(pcsId);
 
@@ -269,6 +273,14 @@
 
                 var currentDateTime = await client.SendAsync(User.GetAccessToken(), new GetApiUtcDate());
 
+                var returnQueryString = ManageEvidenceNotesController.BuildReturnQueryString(
+                    return_tab, return_page, return_selectedComplianceYear,
+                    return_startDate, return_endDate, return_searchRef,
+                    return_receivedId, return_wasteTypeValue, return_evidenceNoteTypeValue,
+                    return_noteStatusValue, return_submittedBy);
+
+                var effectiveQueryString = !string.IsNullOrEmpty(returnQueryString) ? returnQueryString : queryString;
+
                 var model = mapper.Map<ViewTransferNoteViewModel>(new ViewTransferNoteViewModelMapTransfer(pcsId,
                     noteData, TempData[ViewDataConstant.TransferEvidenceNoteDisplayNotification])
                 {
@@ -276,7 +288,7 @@
                     SystemDateTime = currentDateTime,
                     Page = page,
                     OpenedInNewTab = openedInNewTab,
-                    QueryString = queryString
+                    QueryString = effectiveQueryString
                 });
 
                 if (!string.IsNullOrEmpty(linkType) && linkType == "View")

--- a/src/EA.Weee.Web/Areas/Scheme/Views/ManageEvidenceNotes/OutgoingTransfers.cshtml
+++ b/src/EA.Weee.Web/Areas/Scheme/Views/ManageEvidenceNotes/OutgoingTransfers.cshtml
@@ -90,6 +90,7 @@
                         <tbody class="govuk-table__body">
                             @if (Model.EvidenceNotesDataList.Any())
                             {
+                                var returnRouteValues = ReturnUrlHelper.BuildReturnRouteValues(Context.Request.QueryString);
                                 foreach (var note in Model.EvidenceNotesDataList)
                                 {
                                     <tr class="govuk-table__row">
@@ -98,14 +99,14 @@
                                         <td class="govuk-table__cell">@note.Recipient</td>
                                         <td class="govuk-table__cell">@note.Status</td>
                                         <td class="govuk-table__cell" style="white-space: nowrap;">
-                                            @Html.NavigationRouteLink("View", "View transfer note with reference " + @note.ReferenceId, note.SchemeViewRouteName, new { pcsId = Model.OrganisationId, evidenceNoteId = @note.Id, selectedComplianceYear = Model.ManageEvidenceNoteViewModel.SelectedComplianceYear, redirectTab = Extensions.ToDisplayString(ManageEvidenceNotesDisplayOptions.OutgoingTransfers), linkType = "View", page = Model.EvidenceNotesDataList.PageNumber, queryString = ReturnUrlHelper.TidyQueryString(@Context.Request.QueryString) }, null)
+                                            @Html.NavigationRouteLink("View", "View transfer note with reference " + @note.ReferenceId, note.SchemeViewRouteName, ReturnUrlHelper.MergeRouteValues(new { pcsId = Model.OrganisationId, evidenceNoteId = @note.Id, selectedComplianceYear = Model.ManageEvidenceNoteViewModel.SelectedComplianceYear, redirectTab = Extensions.ToDisplayString(ManageEvidenceNotesDisplayOptions.OutgoingTransfers), linkType = "View", page = Model.EvidenceNotesDataList.PageNumber }, returnRouteValues), null)
                                             @if (note.DisplayEditLink)
                                             {
-                                                @Html.NavigationRouteLink("Edit", "Edit transfer note with reference " + @note.ReferenceId, "Scheme_edit_transfer", new { pcsId = Model.OrganisationId, evidenceNoteId = @note.Id, selectedComplianceYear = Model.ManageEvidenceNoteViewModel.SelectedComplianceYear, redirectTab = Extensions.ToDisplayString(ManageEvidenceNotesDisplayOptions.OutgoingTransfers), page = Model.EvidenceNotesDataList.PageNumber, queryString = ReturnUrlHelper.TidyQueryString(@Context.Request.QueryString) }, null)
+                                                @Html.NavigationRouteLink("Edit", "Edit transfer note with reference " + @note.ReferenceId, "Scheme_edit_transfer", ReturnUrlHelper.MergeRouteValues(new { pcsId = Model.OrganisationId, evidenceNoteId = @note.Id, selectedComplianceYear = Model.ManageEvidenceNoteViewModel.SelectedComplianceYear, redirectTab = Extensions.ToDisplayString(ManageEvidenceNotesDisplayOptions.OutgoingTransfers), page = Model.EvidenceNotesDataList.PageNumber }, returnRouteValues), null)
                                             }
                                             @if (note.DisplayCancelLink)
                                             {
-                                                @Html.NavigationRouteLink("Cancel", "Cancel transfer note with reference " + @note.ReferenceId, note.SchemeViewRouteName, new { pcsId = Model.OrganisationId, evidenceNoteId = @note.Id, selectedComplianceYear = Model.ManageEvidenceNoteViewModel.SelectedComplianceYear, redirectTab = Extensions.ToDisplayString(ManageEvidenceNotesDisplayOptions.OutgoingTransfers), page = Model.EvidenceNotesDataList.PageNumber, queryString = ReturnUrlHelper.TidyQueryString(@Context.Request.QueryString) }, null)
+                                                @Html.NavigationRouteLink("Cancel", "Cancel transfer note with reference " + @note.ReferenceId, note.SchemeViewRouteName, ReturnUrlHelper.MergeRouteValues(new { pcsId = Model.OrganisationId, evidenceNoteId = @note.Id, selectedComplianceYear = Model.ManageEvidenceNoteViewModel.SelectedComplianceYear, redirectTab = Extensions.ToDisplayString(ManageEvidenceNotesDisplayOptions.OutgoingTransfers), page = Model.EvidenceNotesDataList.PageNumber }, returnRouteValues), null)
                                             }
                                         </td>
                                     </tr>

--- a/src/EA.Weee.Web/Areas/Scheme/Views/ManageEvidenceNotes/ViewAndTransferEvidence.cshtml
+++ b/src/EA.Weee.Web/Areas/Scheme/Views/ManageEvidenceNotes/ViewAndTransferEvidence.cshtml
@@ -131,6 +131,7 @@
                         <tbody class="govuk-table__body">
                             @if (Model.EvidenceNotesDataList.Any())
                             {
+                                var returnRouteValues = EA.Weee.Web.Extensions.ReturnUrlHelper.BuildReturnRouteValues(Context.Request.QueryString);
                                 foreach (var note in Model.EvidenceNotesDataList)
                                 {
                                     <tr class="govuk-table__row">
@@ -149,17 +150,17 @@
                                         <td class="govuk-table__cell">
                                             @if (@note.Type == NoteType.Transfer)
                                             {
-                                                @Html.NavigationRouteLink("View", "View transfer note " + @note.ReferenceDisplay, note.SchemeViewRouteName, new { pcsId = Model.OrganisationId, evidenceNoteId = @note.Id, selectedComplianceYear = Model.ManageEvidenceNoteViewModel.SelectedComplianceYear, redirectTab = ManageEvidenceNotesDisplayOptions.ViewAndTransferEvidence.ToDisplayString(), page = Model.EvidenceNotesDataList.PageNumber, queryString = EA.Weee.Web.Extensions.ReturnUrlHelper.TidyQueryString(@Context.Request.QueryString) }, null)
+                                                @Html.NavigationRouteLink("View", "View transfer note " + @note.ReferenceDisplay, note.SchemeViewRouteName, EA.Weee.Web.Extensions.ReturnUrlHelper.MergeRouteValues(new { pcsId = Model.OrganisationId, evidenceNoteId = @note.Id, selectedComplianceYear = Model.ManageEvidenceNoteViewModel.SelectedComplianceYear, redirectTab = ManageEvidenceNotesDisplayOptions.ViewAndTransferEvidence.ToDisplayString(), page = Model.EvidenceNotesDataList.PageNumber }, returnRouteValues), null)
 
                                                 if (note.DisplayEditLink)
                                                 {
                                                     <br />
-                                                    @Html.NavigationRouteLink("Edit", "Edit returned transfer note " + @note.ReferenceDisplay, "Scheme_edit_transfer", new { pcsId = Model.OrganisationId, evidenceNoteId = @note.Id, selectedComplianceYear = Model.ManageEvidenceNoteViewModel.SelectedComplianceYear, queryString = EA.Weee.Web.Extensions.ReturnUrlHelper.TidyQueryString(@Context.Request.QueryString) }, null)
+                                                    @Html.NavigationRouteLink("Edit", "Edit returned transfer note " + @note.ReferenceDisplay, "Scheme_edit_transfer", EA.Weee.Web.Extensions.ReturnUrlHelper.MergeRouteValues(new { pcsId = Model.OrganisationId, evidenceNoteId = @note.Id, selectedComplianceYear = Model.ManageEvidenceNoteViewModel.SelectedComplianceYear }, returnRouteValues), null)
                                                 }
                                             }
                                             else
                                             {
-                                                @Html.NavigationRouteLink("View", "View evidence note with reference ID " + @note.ReferenceDisplay, note.SchemeViewRouteName, new { pcsId = Model.OrganisationId, evidenceNoteId = @note.Id, selectedComplianceYear = Model.ManageEvidenceNoteViewModel.SelectedComplianceYear, redirectTab = ManageEvidenceNotesDisplayOptions.ViewAndTransferEvidence.ToDisplayString(), page = Model.EvidenceNotesDataList.PageNumber, queryString = EA.Weee.Web.Extensions.ReturnUrlHelper.TidyQueryString(@Context.Request.QueryString) }, null)
+                                                @Html.NavigationRouteLink("View", "View evidence note with reference ID " + @note.ReferenceDisplay, note.SchemeViewRouteName, EA.Weee.Web.Extensions.ReturnUrlHelper.MergeRouteValues(new { pcsId = Model.OrganisationId, evidenceNoteId = @note.Id, selectedComplianceYear = Model.ManageEvidenceNoteViewModel.SelectedComplianceYear, redirectTab = ManageEvidenceNotesDisplayOptions.ViewAndTransferEvidence.ToDisplayString(), page = Model.EvidenceNotesDataList.PageNumber }, returnRouteValues), null)
                                             }
                                         </td>
                                     </tr>

--- a/src/EA.Weee.Web/Areas/Scheme/Views/Shared/_ReviewSubmittedEvidencePartial.cshtml
+++ b/src/EA.Weee.Web/Areas/Scheme/Views/Shared/_ReviewSubmittedEvidencePartial.cshtml
@@ -44,10 +44,10 @@
                 {
                     <div class="govuk-grid-column-one-quater govuk-grid-column-one-quater-from-desktop govuk-!-padding-top-6">
                         @Html.Partial("~/Views/Shared/_SearchFilterButtonsPartial.cshtml", Model.ManageEvidenceNoteViewModel,
-                          new ViewDataDictionary()
-                          {
+                               new ViewDataDictionary()
+                               {
                             new KeyValuePair<string, object>("tab", EA.Weee.Core.Helpers.Extensions.ToDisplayString(ManageEvidenceNotesDisplayOptions.ReviewSubmittedEvidence))
-                          })
+                           })
                     </div>
                 }
             </div>
@@ -60,10 +60,10 @@
 
                     <div class="govuk-grid-column-one-half govuk-grid-column-one-half-from-desktop govuk-!-padding-top-6">
                         @Html.Partial("~/Views/Shared/_SearchFilterButtonsPartial.cshtml", Model.ManageEvidenceNoteViewModel,
-                         new ViewDataDictionary()
-                         {
+                              new ViewDataDictionary()
+                              {
                             new KeyValuePair<string, object>("tab", EA.Weee.Core.Helpers.Extensions.ToDisplayString(ManageEvidenceNotesDisplayOptions.ReviewSubmittedEvidence))
-                         })
+                          })
                     </div>
                 </div>
             }
@@ -94,6 +94,7 @@
         <tbody class="govuk-table__body">
             @if (Model.EvidenceNotesDataList.Any())
             {
+                var returnRouteValues = ReturnUrlHelper.BuildReturnRouteValues(Context.Request.QueryString);
                 foreach (var note in Model.EvidenceNotesDataList)
                 {
                     <tr class="govuk-table__row">
@@ -115,23 +116,23 @@
                                 {
                                     if (Model.SchemeInfo != null)
                                     {
-                                        @Html.NavigationRouteLink("Review evidence", "Review evidence note with reference ID " + @note.ReferenceDisplay, "Scheme_evidence_default", new { action = "ReviewEvidenceNote", controller = "ManageEvidenceNotes", pcsId = Model.OrganisationId, evidenceNoteId = @note.Id, selectedComplianceYear = Model.ManageEvidenceNoteViewModel.SelectedComplianceYear, queryString = ReturnUrlHelper.TidyQueryString(@Context.Request.QueryString) }, null)
+                                        @Html.NavigationRouteLink("Review evidence", "Review evidence note with reference ID " + @note.ReferenceDisplay, "Scheme_evidence_default", ReturnUrlHelper.MergeRouteValues(new { action = "ReviewEvidenceNote", controller = "ManageEvidenceNotes", pcsId = Model.OrganisationId, evidenceNoteId = @note.Id, selectedComplianceYear = Model.ManageEvidenceNoteViewModel.SelectedComplianceYear }, returnRouteValues), null)
                                     }
                                 }
                                 else
                                 {
-                                    @Html.NavigationRouteLink("View", "View evidence note with reference ID " + @note.ReferenceDisplay, "Scheme_evidence_default", new { action = "ViewEvidenceNote", controller = "ManageEvidenceNotes", pcsId = Model.OrganisationId, evidenceNoteId = @note.Id, selectedComplianceYear = Model.ManageEvidenceNoteViewModel.SelectedComplianceYear, redirectTab = Extensions.ToDisplayString(ManageEvidenceNotesDisplayOptions.ReviewSubmittedEvidence), queryString = ReturnUrlHelper.TidyQueryString(@Context.Request.QueryString) }, null)
+                                    @Html.NavigationRouteLink("View", "View evidence note with reference ID " + @note.ReferenceDisplay, "Scheme_evidence_default", ReturnUrlHelper.MergeRouteValues(new { action = "ViewEvidenceNote", controller = "ManageEvidenceNotes", pcsId = Model.OrganisationId, evidenceNoteId = @note.Id, selectedComplianceYear = Model.ManageEvidenceNoteViewModel.SelectedComplianceYear, redirectTab = Extensions.ToDisplayString(ManageEvidenceNotesDisplayOptions.ReviewSubmittedEvidence) }, returnRouteValues), null)
                                 }
                             }
                             else
                             {
                                 if (Model.CanSchemeManageEvidence)
                                 {
-                                    @Html.NavigationRouteLink("Review evidence", "Review evidence note with reference ID " + @note.ReferenceDisplay, SchemeTransferEvidenceRedirect.ReviewSubmittedTransferEvidenceRouteName, new { pcsId = Model.OrganisationId, evidenceNoteId = @note.Id, selectedComplianceYear = Model.ManageEvidenceNoteViewModel.SelectedComplianceYear, area = "Scheme", returnToView = false, redirectTab = Extensions.ToDisplayString(ManageEvidenceNotesDisplayOptions.ReviewSubmittedEvidence), queryString = ReturnUrlHelper.TidyQueryString(@Context.Request.QueryString) }, null)
+                                    @Html.NavigationRouteLink("Review evidence", "Review evidence note with reference ID " + @note.ReferenceDisplay, SchemeTransferEvidenceRedirect.ReviewSubmittedTransferEvidenceRouteName, ReturnUrlHelper.MergeRouteValues(new { pcsId = Model.OrganisationId, evidenceNoteId = @note.Id, selectedComplianceYear = Model.ManageEvidenceNoteViewModel.SelectedComplianceYear, area = "Scheme", returnToView = false, redirectTab = Extensions.ToDisplayString(ManageEvidenceNotesDisplayOptions.ReviewSubmittedEvidence) }, returnRouteValues), null)
                                 }
                                 else
                                 {
-                                    @Html.NavigationRouteLink("View", "View transfer note with reference ID " + @note.ReferenceDisplay, note.SchemeViewRouteName, new { pcsId = Model.OrganisationId, evidenceNoteId = @note.Id, selectedComplianceYear = Model.ManageEvidenceNoteViewModel.SelectedComplianceYear, redirectTab = Extensions.ToDisplayString(ManageEvidenceNotesDisplayOptions.ReviewSubmittedEvidence), queryString = ReturnUrlHelper.TidyQueryString(@Context.Request.QueryString) }, null)
+                                    @Html.NavigationRouteLink("View", "View transfer note with reference ID " + @note.ReferenceDisplay, note.SchemeViewRouteName, ReturnUrlHelper.MergeRouteValues(new { pcsId = Model.OrganisationId, evidenceNoteId = @note.Id, selectedComplianceYear = Model.ManageEvidenceNoteViewModel.SelectedComplianceYear, redirectTab = Extensions.ToDisplayString(ManageEvidenceNotesDisplayOptions.ReviewSubmittedEvidence) }, returnRouteValues), null)
                                 }
                             }
                         </td>

--- a/src/EA.Weee.Web/Extensions/ReturnUrlHelper.cs
+++ b/src/EA.Weee.Web/Extensions/ReturnUrlHelper.cs
@@ -4,24 +4,90 @@
     using System.Collections.Generic;
     using System.Collections.Specialized;
     using System.Linq;
+    using System.Web.Routing;
 
     public static class ReturnUrlHelper
     {
+        private static readonly HashSet<string> ReturnParameterNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "tab", "page", "selectedComplianceYear", "startDate", "endDate",
+            "searchRef", "receivedId", "wasteTypeValue", "evidenceNoteTypeValue",
+            "noteStatusValue", "submittedBy"
+        };
+
+        private static readonly List<string> PropertiesToIgnore = new List<string>()
+        {
+            "ManageEvidenceNoteViewModel_RecipientWasteStatusFilterViewModel_SubmittedBy-auto",
+            "ManageEvidenceNoteViewModel_RecipientWasteStatusFilterViewModel_ReceivedId-auto"
+        };
+
+        public const string ReturnPrefix = "return_";
+
+        /// <summary>
+        /// Extracts filter parameters from the current request query string and returns
+        /// them as a RouteValueDictionary with "return_" prefixed keys.
+        /// </summary>
+        public static RouteValueDictionary BuildReturnRouteValues(NameValueCollection queryString)
+        {
+            var result = new RouteValueDictionary();
+
+            if (queryString == null || !queryString.HasKeys())
+            {
+                return result;
+            }
+
+            foreach (string key in queryString.AllKeys)
+            {
+                if (string.IsNullOrEmpty(key) || PropertiesToIgnore.Contains(key))
+                {
+                    continue;
+                }
+
+                var value = queryString[key];
+                if (string.IsNullOrEmpty(value))
+                {
+                    continue;
+                }
+
+                if (ReturnParameterNames.Contains(key))
+                {
+                    result[ReturnPrefix + key] = value;
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Merges an anonymous object of primary route values with a RouteValueDictionary of return parameters.
+        /// </summary>
+        public static RouteValueDictionary MergeRouteValues(object primaryValues, RouteValueDictionary returnValues)
+        {
+            var result = new RouteValueDictionary(primaryValues);
+
+            if (returnValues != null)
+            {
+                foreach (var kvp in returnValues)
+                {
+                    result[kvp.Key] = kvp.Value;
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Legacy method - kept for backward compatibility with views not yet migrated (Admin, Aatf).
+        /// </summary>
         public static string TidyQueryString(NameValueCollection queryString)
         {
             if (queryString != null && queryString.HasKeys())
             {
-                var propertiesToIgnore = new List<string>()
-                {
-                    "ManageEvidenceNoteViewModel_RecipientWasteStatusFilterViewModel_SubmittedBy-auto",
-                    "ManageEvidenceNoteViewModel_RecipientWasteStatusFilterViewModel_ReceivedId-auto"
-                };
-
                 var filteredQuery = queryString.ToString()
                     .Split('&')
                     .Where(q => !string.IsNullOrEmpty(q.Split('=')[1]) &&
                                 (!string.IsNullOrEmpty(q.Split('=')[0]) &&
-                                 !propertiesToIgnore.Contains(q.Split('=')[0])))
+                                 !PropertiesToIgnore.Contains(q.Split('=')[0])))
                     .ToList();
 
                 var newQuery = string.Join("&", filteredQuery);


### PR DESCRIPTION
Implement robust "return to filtered list" mechanism for Scheme evidence and transfer note views. Filter and paging parameters are now passed as "return_"-prefixed route values and merged into navigation links, ensuring users return to their original filtered context after viewing or editing a note. Controller actions and views have been updated to support this, and ReturnUrlHelper now provides helpers for extracting and merging return parameters. Dates are now handled as strings and parsed server-side for consistency. This improves usability and consistency for Scheme users managing evidence and transfer notes.

Phase 1: POST-Redirect-GET (PRG) Pattern - Already completed

Phase 2: Flat return_* Parameters

Before (WAF-blocked):
/review-evidence-note/{id}?queryString=tab%3Dreview-submitted%26startDate%3D01%252F04%252F2026
After (WAF-safe):
/review-evidence-note/{id}?return_tab=review-submitted&return_startDate=01-04-2026

All filter values are now flat scalar parameters — no nesting, no double encoding, no WAF triggers.