### PR TITLE
Fix direct registrant data sourcing in public register SP

### DIFF
--- a/src/EA.Weee.Database/scripts/Update/Release 8/Sprint7/20260507-1212-Alter-Producer-spgProducerPublicRegisterCSVDataByComplianceYear.sql
+++ b/src/EA.Weee.Database/scripts/Update/Release 8/Sprint7/20260507-1212-Alter-Producer-spgProducerPublicRegisterCSVDataByComplianceYear.sql
@@ -1,6 +1,4 @@
-﻿GO
-/****** Object:  StoredProcedure [Producer].[spgProducerPublicRegisterCSVDataByComplianceYear]    Script Date: 07/05/2026 ******/
-SET ANSI_NULLS ON
+﻿SET ANSI_NULLS ON
 GO
 
 -- Modified Date: 07/05/2026 11:00:00 Ian Alvarado - Fix to use per-compliance-year DirectProducerSubmissionHistory for CompanyName, TradingName, 
@@ -11,36 +9,36 @@ GO
 SET QUOTED_IDENTIFIER ON
 GO
 ALTER PROCEDURE [Producer].[spgProducerPublicRegisterCSVDataByComplianceYear]
-        @ComplianceYear INT
+	@ComplianceYear INT
 AS
 BEGIN
 SET NOCOUNT ON;
 
 -- Scheme producer query (unchanged)
 SELECT
-    -- Company and Producer details
-    PBC.Name AS 'CompanyName',
-    CASE 
-        WHEN PBC.Name IS NULL THEN PBP.Name
-        ELSE PBC.Name
-    END AS 'ProducerName',
-    PS.TradingName,
-    PS.ObligationType,
+	-- Company and Producer details
+	PBC.Name AS 'CompanyName',
+	CASE 
+		WHEN PBC.[Name] IS NULL THEN PBP.[Name]
+		ELSE PBC.[Name]
+	END AS 'ProducerName',
+	PS.TradingName,
+	PS.ObligationType,
 
-    -- Registered Office Address
-    ROC_A.PrimaryName AS 'ROAPrimaryName',
-    ROC_A.SecondaryName AS 'ROASecondaryName',
-    ROC_A.Street AS 'ROAStreet',
-    ROC_A.Town AS 'ROATown',
-    ROC_A.Locality AS 'ROALocality',
-    ROC_A.AdministrativeArea AS 'ROAAdministrativeArea',
-    ROC_A.PostCode AS 'ROAPostCode',
-    ROC_A_C.Name AS 'ROACountry',
+	-- Registered Office Address
+	ROC_A.PrimaryName AS 'ROAPrimaryName',
+	ROC_A.SecondaryName AS 'ROASecondaryName',
+	ROC_A.Street AS 'ROAStreet',
+	ROC_A.Town AS 'ROATown',
+	ROC_A.Locality AS 'ROALocality',
+	ROC_A.AdministrativeArea AS 'ROAAdministrativeArea',
+	ROC_A.PostCode AS 'ROAPostCode',
+	ROC_A_C.Name AS 'ROACountry',
 
-    -- Registered Office Contact Details
-    CASE
+	-- Registered Office Contact Details
+	CASE
 		WHEN ORG.OrganisationType = 1 THEN ROC.Telephone
-		ELSE NULL 
+		ELSE NULL
 	END AS 'ROATelephone',
 	CASE
 		WHEN ORG.OrganisationType = 1 THEN ROC.Email
@@ -51,246 +49,235 @@ SELECT
 		ELSE NULL
 	END AS 'ROAFax',
 
-    -- Producer Registration Number
-    RP.ProducerRegistrationNumber AS 'PRN',
-    
-    -- Compliance Scheme Details
-    S.SchemeName,
-    CASE 
-        WHEN ORG.Name IS NULL THEN ORG.TradingName
-        ELSE ORG.Name
-    END AS 'SchemeOperator',
+	-- Producer Registration Number
+	RP.ProducerRegistrationNumber AS 'PRN',
 
-    -- Compliance Scheme Registered Office
-    ORG_A.Address1 AS 'CSROAAddress1',
-    ORG_A.Address2 AS 'CSROAAddress2',
-    ORG_A.TownOrCity AS 'CSROATownOrCity',
-    ORG_A.CountyOrRegion AS 'CSROACountyOrRegion',
-    ORG_A.Postcode AS 'CSROAPostcode',
-    ORG_A_C.Name AS 'CSROACountry',
+	-- Compliance Scheme Details
+	S.SchemeName,
+	CASE 
+		WHEN ORG.[Name] IS NULL THEN ORG.TradingName
+		ELSE ORG.[Name]
+	END AS 'SchemeOperator',
 
-    -- Overseas Producer Details
-    AR.OverseasProducerName AS 'OPNAName',
-    OC_A.PrimaryName AS 'OPNAPrimaryName',
-    OC_A.SecondaryName AS 'OPNASecondaryName',
-    OC_A.Street AS 'OPNAStreet',
-    OC_A.Town AS 'OPNATown',
-    OC_A.Locality AS 'OPNALocality',
-    OC_A.AdministrativeArea AS 'OPNAAdministrativeArea', 
-    OC_A_C.Name AS 'OPNACountry',
-    OC_A.PostCode AS 'OPNAPostCode',
+	-- Compliance Scheme Registered Office
+	ORG_A.Address1 AS 'CSROAAddress1',
+	ORG_A.Address2 AS 'CSROAAddress2',
+	ORG_A.TownOrCity AS 'CSROATownOrCity',
+	ORG_A.CountyOrRegion AS 'CSROACountyOrRegion',
+	ORG_A.Postcode AS 'CSROAPostcode',
+	ORG_A_C.[Name] AS 'CSROACountry',
 
-    MU.ComplianceYear,
+	-- Overseas Producer Details
+	AR.OverseasProducerName AS 'OPNAName',
+	OC_A.PrimaryName AS 'OPNAPrimaryName',
+	OC_A.SecondaryName AS 'OPNASecondaryName',
+	OC_A.Street AS 'OPNAStreet',
+	OC_A.Town AS 'OPNATown',
+	OC_A.Locality AS 'OPNALocality',
+	OC_A.AdministrativeArea AS 'OPNAAdministrativeArea', 
+	OC_A_C.[Name] AS 'OPNACountry',
+	OC_A.PostCode AS 'OPNAPostCode',
 
-    -- Principal Place of Business
-    PPOB_A.PrimaryName AS 'PPOBPrimaryName',
-    PPOB_A.SecondaryName AS 'PPOBSecondaryName',
-    PPOB_A.Street AS 'PPOBStreet',
-    PPOB_A.Town AS 'PPOBTown',
-    PPOB_A.Locality AS 'PPOBLocality',
-    PPOB_A.AdministrativeArea AS 'PPOBAdministrativeArea',
-    PPOB_A_C.Name AS 'PPOBCountry',
-    PPOB_A.PostCode AS 'PPOBPostcode',
-    0 AS IsDirectProducer
+	MU.ComplianceYear,
+
+	-- Principal Place of Business
+	PPOB_A.PrimaryName AS 'PPOBPrimaryName',
+	PPOB_A.SecondaryName AS 'PPOBSecondaryName',
+	PPOB_A.Street AS 'PPOBStreet',
+	PPOB_A.Town AS 'PPOBTown',
+	PPOB_A.Locality AS 'PPOBLocality',
+	PPOB_A.AdministrativeArea AS 'PPOBAdministrativeArea',
+	PPOB_A_C.[Name] AS 'PPOBCountry',
+	PPOB_A.PostCode AS 'PPOBPostcode',
+	0 AS IsDirectProducer
 
 FROM Producer.RegisteredProducer RP
 INNER JOIN Producer.ProducerSubmission PS ON RP.CurrentSubmissionId = PS.Id
 INNER JOIN PCS.MemberUpload MU ON PS.MemberUploadId = MU.Id
 INNER JOIN Pcs.Scheme S ON MU.SchemeId = S.Id
 INNER JOIN Organisation.Organisation ORG ON ORG.Id = S.OrganisationId
-INNER JOIN Organisation.Address ORG_A ON ORG.BusinessAddressId = ORG_A.Id
-INNER JOIN Lookup.Country ORG_A_C ON ORG_A.CountryId = ORG_A_C.Id
+INNER JOIN [Organisation].[Address] ORG_A ON ORG.BusinessAddressId = ORG_A.Id
+INNER JOIN [Lookup].[Country] ORG_A_C ON ORG_A.CountryId = ORG_A_C.Id
 
 -- Authorized Representative
 LEFT JOIN Producer.AuthorisedRepresentative AR ON PS.AuthorisedRepresentativeId = AR.Id
 LEFT JOIN Producer.Contact OC ON AR.OverseasContactId = OC.Id
-LEFT JOIN Producer.Address OC_A ON OC.AddressId = OC_A.Id
-LEFT JOIN Lookup.Country OC_A_C ON OC_A.CountryId = OC_A_C.Id
+LEFT JOIN [Producer].[Address] OC_A ON OC.AddressId = OC_A.Id
+LEFT JOIN [Lookup].[Country] OC_A_C ON OC_A.CountryId = OC_A_C.Id
 
 -- Producer Business
 LEFT JOIN Producer.Business PB ON PS.ProducerBusinessId = PB.Id
 LEFT JOIN Producer.Contact CFNC ON PB.CorrespondentForNoticesContactId = CFNC.Id
-LEFT JOIN Producer.Address CFNC_A ON CFNC.AddressId = CFNC_A.Id
-LEFT JOIN Lookup.Country CFNC_A_C ON CFNC_A.CountryId = CFNC_A_C.Id
+LEFT JOIN Producer.[Address] CFNC_A ON CFNC.AddressId = CFNC_A.Id
+LEFT JOIN [Lookup].[Country] CFNC_A_C ON CFNC_A.CountryId = CFNC_A_C.Id
 
 -- Producer Company
 LEFT JOIN Producer.Company PBC ON PB.CompanyId = PBC.Id
 LEFT JOIN Producer.Contact ROC ON PBC.RegisteredOfficeContactId = ROC.Id
-LEFT JOIN Producer.Address ROC_A ON ROC.AddressId = ROC_A.Id
-LEFT JOIN Lookup.Country ROC_A_C ON ROC_A.CountryId = ROC_A_C.Id
+LEFT JOIN Producer.[Address] ROC_A ON ROC.AddressId = ROC_A.Id
+LEFT JOIN [Lookup].[Country] ROC_A_C ON ROC_A.CountryId = ROC_A_C.Id
 
 -- Producer Partnership
 LEFT JOIN Producer.Partnership PBP ON PB.PartnershipId = PBP.Id
 LEFT JOIN Producer.Contact PPOB ON PBP.PrincipalPlaceOfBusinessId = PPOB.Id
-LEFT JOIN Producer.Address PPOB_A ON PPOB.AddressId = PPOB_A.Id
-LEFT JOIN Lookup.Country PPOB_A_C ON PPOB_A.CountryId = PPOB_A_C.Id
+LEFT JOIN [Producer].[Address] PPOB_A ON PPOB.AddressId = PPOB_A.Id
+LEFT JOIN [Lookup].[Country] PPOB_A_C ON PPOB_A.CountryId = PPOB_A_C.Id
 
 -- Subquery to get the first submission for each producer
 INNER JOIN (
-    SELECT
-        PS.RegisteredProducerId,
-        ROW_NUMBER() OVER (
-            PARTITION BY PS.RegisteredProducerId
-            ORDER BY PS.UpdatedDate
-        ) AS RowNumber
-    FROM Producer.ProducerSubmission PS
-    INNER JOIN PCS.MemberUpload MU ON PS.MemberUploadId = MU.Id
-    INNER JOIN Producer.RegisteredProducer RP ON PS.RegisteredProducerId = RP.Id
-    WHERE MU.IsSubmitted = 1 AND RP.Removed = 0
+	SELECT
+		PS.RegisteredProducerId,
+		ROW_NUMBER() OVER (
+			PARTITION BY PS.RegisteredProducerId
+			ORDER BY PS.UpdatedDate
+		) AS RowNumber
+	FROM Producer.ProducerSubmission PS
+	INNER JOIN PCS.MemberUpload MU ON PS.MemberUploadId = MU.Id
+	INNER JOIN Producer.RegisteredProducer RP ON PS.RegisteredProducerId = RP.Id
+	WHERE MU.IsSubmitted = 1 AND RP.Removed = 0
 ) P_First ON PS.RegisteredProducerId = P_First.RegisteredProducerId AND P_First.RowNumber = 1
 
 -- Partners subquery
 LEFT JOIN (
-    SELECT DISTINCT 
-        P.Id, 
-        STUFF((
-            SELECT DISTINCT '; ' + PP.Name
-            FROM Producer.Partner PP 
-            WHERE P.Id = PP.PartnershipId
-            FOR XML PATH(''), TYPE
-        ).value('.', 'NVARCHAR(MAX)'), 1, 2, '') AS Partners
-    FROM Producer.Partnership P
+	SELECT DISTINCT 
+		P.Id,
+		STUFF((
+		SELECT DISTINCT '; ' + PP.[Name]
+			FROM Producer.Partner PP 
+			WHERE P.Id = PP.PartnershipId
+			FOR XML PATH(''), TYPE
+		).value('.', 'NVARCHAR(MAX)'), 1, 2, '') AS Partners
+	FROM Producer.Partnership P
 ) Partners ON PBP.Id = Partners.Id
 
 WHERE
-    MU.ComplianceYear = @ComplianceYear
-    AND RP.Removed = 0
+	MU.ComplianceYear = @ComplianceYear
+	AND RP.Removed = 0
 
 UNION ALL
 
-    -- Direct registrant dataset
-    -- FIX: Use per-compliance-year DirectProducerSubmissionHistory for CompanyName, TradingName,
-    SELECT
-        -- CompanyName: prefer the value recorded at submission time; fall back to root org name
-        COALESCE(dpsh.CompanyName, o.[Name]) AS 'CompanyName',
-        COALESCE(dpsh.CompanyName, o.[Name]) AS 'ProducerName',
+	-- Direct registrant dataset
+	-- FIX: Use per-compliance-year DirectProducerSubmissionHistory for CompanyName, TradingName,
+	--      BusinessAddress and AuthorisedRepresentative rather than the shared root entity fields
+	--      on Organisation and DirectRegistrant, which are no longer synced on submission completion.
+	SELECT
+		-- CompanyName/ProducerName: prefer value recorded at submission time, fall back to root org name
+		COALESCE(DPSH.CompanyName, O.[Name]) AS 'CompanyName',
+		COALESCE(DPSH.CompanyName, O.[Name]) AS 'ProducerName',
 
-        -- TradingName: prefer the value recorded at submission time; fall back to root org trading name
-        COALESCE(dpsh.TradingName, o.[TradingName]) AS 'TradingName',
+		-- TradingName: prefer value recorded at submission time, fall back to root org trading name
+		COALESCE(DPSH.TradingName, O.[TradingName]) AS 'TradingName',
 
-        dbo.GetObligationType(eorv.Id) AS 'ObligationType',
+		dbo.GetObligationType(EORV.Id) AS 'ObligationType',
 
-        -- Business address: prefer address stored in submission history for the compliance year;
-        -- fall back to root organisation address for migrated/legacy records without a history address
-        COALESCE(hist_ba.Address1,      oa.Address1)      AS 'ROAPrimaryName',
-        NULL                                               AS 'ROASecondaryName',
-        COALESCE(hist_ba.Address2,      oa.Address2)      AS 'ROAStreet',
-        COALESCE(hist_ba.TownOrCity,    oa.TownOrCity)    AS 'ROATown',
-        COALESCE(hist_ba.CountyOrRegion,oa.CountyOrRegion)AS 'ROALocality',
-        NULL                                               AS 'ROAAdministrativeArea',
-        COALESCE(hist_ba.PostCode,      oa.PostCode)      AS 'ROAPostCode',
-        COALESCE(hist_loc.Name,         loc.Name)         AS 'ROACountry',
+		-- Business address: prefer address stored in submission history for this compliance year;
+		-- fall back to root organisation address for migrated/legacy records without a history address
+		COALESCE(HIST_BA.Address1,       OA.Address1)       AS 'ROAPrimaryName',
+		NULL                                                 AS 'ROASecondaryName',
+		COALESCE(HIST_BA.Address2,       OA.Address2)        AS 'ROAStreet',
+		COALESCE(HIST_BA.TownOrCity,     OA.TownOrCity)      AS 'ROATown',
+		COALESCE(HIST_BA.CountyOrRegion, OA.CountyOrRegion)  AS 'ROALocality',
+		NULL                                                 AS 'ROAAdministrativeArea',
+		COALESCE(HIST_BA.PostCode,       OA.PostCode)        AS 'ROAPostCode',
+		COALESCE(HIST_LOC.[Name],        LOC.[Name])         AS 'ROACountry',
 
-        -- Registered Office Contact Details (telephone/email/fax come from the business address record)
-        CASE
-            WHEN o.OrganisationType = 1 THEN COALESCE(hist_ba.Telephone, oa.Telephone)
-            ELSE NULL
-        END AS 'ROATelephone',
-        CASE
-            WHEN o.OrganisationType = 1 THEN COALESCE(hist_ba.Email, oa.Email)
-            ELSE NULL
-        END AS 'ROAEmail',
-        CASE
-            WHEN o.OrganisationType = 1 THEN COALESCE(hist_ba.Fax, oa.Fax)
-            ELSE NULL
-        END AS 'ROAFax',
+		-- Telephone/email/fax from business address: prefer history, fall back to root
+		CASE WHEN O.OrganisationType = 1 THEN COALESCE(HIST_BA.Telephone, OA.Telephone) ELSE NULL END AS 'ROATelephone',
+		CASE WHEN O.OrganisationType = 1 THEN COALESCE(HIST_BA.Email,     OA.Email)     ELSE NULL END AS 'ROAEmail',
+		CASE WHEN O.OrganisationType = 1 THEN COALESCE(HIST_BA.Fax,       OA.Fax)       ELSE NULL END AS 'ROAFax',
 
-        rp.ProducerRegistrationNumber AS 'PRN',
-        'Direct registrant'           AS 'SchemeName',
-        NULL AS 'SchemeOperator',
-        NULL AS 'CSROAAddress1',
-        NULL AS 'CSROAAddress2',
-        NULL AS 'CSROATownOrCity',
-        NULL AS 'CSROACountyOrRegion',
-        NULL AS 'CSROAPostcode',
-        NULL AS 'CSROACountry',
+		RP.ProducerRegistrationNumber AS 'PRN',
+		'Direct registrant' AS SchemeName,
+		NULL AS 'SchemeOperator',
+		NULL AS 'CSROAAddress1',
+		NULL AS 'CSROAAddress2',
+		NULL AS 'CSROATownOrCity',
+		NULL AS 'CSROACountyOrRegion',
+		NULL AS 'CSROAPostcode',
+		NULL AS 'CSROACountry',
+		AP.OverseasProducerName AS 'OPNAName',
+		PA.PrimaryName AS 'OPNAPrimaryName',
+		PA.SecondaryName AS 'OPNASecondaryName',
+		PA.Street AS 'OPNAStreet',
+		PA.Town AS 'OPNATown',
+		PA.Locality AS 'OPNALocality',
+		PA.AdministrativeArea AS 'OPNAAdministrativeArea',
+		AC.[Name] AS 'OPNACountry',
+		PA.PostCode AS 'OPNAPostCode',
+		DPS.ComplianceYear,
+		NULL AS 'PPOBPrimaryName',
+		NULL AS 'PPOBSecondaryName',
+		NULL AS 'PPOBStreet',
+		NULL AS 'PPOBTown',
+		NULL AS 'PPOBLocality',
+		NULL AS 'PPOBAdministrativeArea',
+		NULL AS 'PPOBCountry',
+		NULL AS 'PPOBPostcode',
+		1 AS IsDirectProducer
+	FROM
+		[Producer].[DirectProducerSubmission] DPS
+		INNER JOIN [Producer].[DirectRegistrant]  DR  ON DR.Id  = DPS.DirectRegistrantId
+		INNER JOIN [Organisation].[Organisation]  O   ON O.Id   = DR.OrganisationId
+		-- Root org address retained as fall-back for legacy/migrated records
+		INNER JOIN [Organisation].[Address]       OA  ON OA.Id  = O.BusinessAddressId
+		INNER JOIN [Organisation].[Contact]       OC  ON OC.Id  = DR.ContactId
+		INNER JOIN [Lookup].[Country]             LOC ON LOC.Id = OA.CountryId
+		INNER JOIN [Producer].[RegisteredProducer] RP ON RP.Id  = DPS.RegisteredProducerId
+		                                              AND DPS.ComplianceYear = @ComplianceYear
 
-        -- Overseas producer (authorised representative): prefer history-level auth rep
-        ap.OverseasProducerName AS 'OPNAName',
-        pa.PrimaryName          AS 'OPNAPrimaryName',
-        pa.SecondaryName        AS 'OPNASecondaryName',
-        pa.Street               AS 'OPNAStreet',
-        pa.Town                 AS 'OPNATown',
-        pa.Locality             AS 'OPNALocality',
-        pa.AdministrativeArea   AS 'OPNAAdministrativeArea',
-        ac.Name                 AS 'OPNACountry',
-        pa.PostCode             AS 'OPNAPostCode',
+		-- Latest submitted history row for this compliance-year submission.
+		-- CompanyName, TradingName, BusinessAddressId and AuthorisedRepresentativeId
+		-- are now read from here rather than from the root entity.
+		INNER JOIN (
+			SELECT
+				DirectProducerSubmissionId,
+				EeeOutputReturnVersionId,
+				Id,
+				CompanyName,
+				TradingName,
+				BusinessAddressId,
+				AuthorisedRepresentativeId,
+				ROW_NUMBER() OVER (PARTITION BY DirectProducerSubmissionId ORDER BY SubmittedDate DESC) AS RowNum
+			FROM [Producer].[DirectProducerSubmissionHistory]
+			WHERE SubmittedDate IS NOT NULL
+		) DPSH ON DPSH.DirectProducerSubmissionId = DPS.Id AND DPSH.RowNum = 1
 
-        dps.ComplianceYear,
-        NULL AS 'PPOBPrimaryName',
-        NULL AS 'PPOBSecondaryName',
-        NULL AS 'PPOBStreet',
-        NULL AS 'PPOBTown',
-        NULL AS 'PPOBLocality',
-        NULL AS 'PPOBAdministrativeArea',
-        NULL AS 'PPOBCountry',
-        NULL AS 'PPOBPostcode',
-        1    AS IsDirectProducer
+		LEFT JOIN [PCS].[EeeOutputReturnVersion] EORV ON EORV.Id = DPSH.EeeOutputReturnVersionId
 
-    FROM [Producer].[DirectProducerSubmission] dps
-        INNER JOIN [Producer].[DirectRegistrant]    dr  ON dr.Id  = dps.DirectRegistrantId
-        INNER JOIN [Organisation].[Organisation]     o   ON o.Id   = dr.OrganisationId
-        -- Root org address kept as a fall-back for legacy/migrated records
-        INNER JOIN [Organisation].[Address]          oa  ON oa.Id  = o.BusinessAddressId
-        INNER JOIN [Lookup].[Country]                loc ON loc.Id = oa.CountryId
-        INNER JOIN [Producer].[RegisteredProducer]   rp  ON rp.Id  = dps.RegisteredProducerId
-                                                         AND dps.ComplianceYear = @ComplianceYear
+		-- Business address from submission history (replaces direct join to root org address)
+		LEFT JOIN [Organisation].[Address] HIST_BA  ON HIST_BA.Id  = DPSH.BusinessAddressId
+		LEFT JOIN [Lookup].[Country]       HIST_LOC ON HIST_LOC.Id = HIST_BA.CountryId
 
-        -- Latest submitted history row for this compliance-year submission
-        INNER JOIN (
-            SELECT
-                DirectProducerSubmissionId,
-                EeeOutputReturnVersionId,
-                Id,
-                -- Per-year fields that must NOT fall back to root entity
-                CompanyName,
-                TradingName,
-                BusinessAddressId,
-                AuthorisedRepresentativeId,
-                ROW_NUMBER() OVER (
-                    PARTITION BY DirectProducerSubmissionId
-                    ORDER BY SubmittedDate DESC
-                ) AS RowNum
-            FROM [Producer].[DirectProducerSubmissionHistory]
-            WHERE SubmittedDate IS NOT NULL
-        ) dpsh ON dpsh.DirectProducerSubmissionId = dps.Id AND dpsh.RowNum = 1
+		-- Authorised representative: prefer the one recorded in submission history;
+		-- fall back to root DirectRegistrant authorised representative for migrated records
+		LEFT JOIN [Producer].[AuthorisedRepresentative] AP ON AP.Id = COALESCE(DPSH.AuthorisedRepresentativeId, DR.AuthorisedRepresentativeId)
+		LEFT JOIN [Producer].[Contact] PC ON PC.Id = AP.OverseasContactId
+		LEFT JOIN [Producer].[Address] PA ON PA.Id = PC.AddressId
+		LEFT JOIN [Lookup].[Country]   AC ON AC.Id = PA.CountryId
 
-        LEFT JOIN [PCS].[EeeOutputReturnVersion] eorv ON eorv.Id = dpsh.EeeOutputReturnVersionId
-
-        -- Business address stored in the submission history for this compliance year
-        -- Replaces the direct join to root Organisation.BusinessAddressId
-        LEFT JOIN [Organisation].[Address] hist_ba  ON hist_ba.Id  = dpsh.BusinessAddressId
-        LEFT JOIN [Lookup].[Country]       hist_loc ON hist_loc.Id = hist_ba.CountryId
-
-        -- Authorised representative: prefer the one recorded in the submission history;
-        -- fall back to the root DirectRegistrant authorised representative for migrated records
-        LEFT JOIN [Producer].[AuthorisedRepresentative] ap ON ap.Id = COALESCE(dpsh.AuthorisedRepresentativeId, dr.AuthorisedRepresentativeId)
-        LEFT JOIN [Producer].[Contact] pc ON pc.Id = ap.OverseasContactId
-        LEFT JOIN [Producer].[Address] pa ON pa.Id = pc.AddressId
-        LEFT JOIN [Lookup].[Country]   ac ON ac.Id = pa.CountryId
-
-        -- First submission date (used for ordering/filtering, unchanged)
-        INNER JOIN (
-            SELECT
-                ps.RegisteredProducerId,
-                MIN(dpsh_first.SubmittedDate) AS SubmittedDate
-            FROM [Producer].[DirectProducerSubmission] ps
-                INNER JOIN [Producer].[DirectProducerSubmissionHistory] dpsh_first
-                    ON dpsh_first.DirectProducerSubmissionId = ps.Id
-                INNER JOIN [Producer].[RegisteredProducer] rp_first
-                    ON rp_first.Id = ps.RegisteredProducerId
-            WHERE dpsh_first.SubmittedDate IS NOT NULL
-              AND rp_first.Removed = 0
-            GROUP BY ps.RegisteredProducerId
-        ) firstSubmitted ON firstSubmitted.RegisteredProducerId = dps.RegisteredProducerId
-
-    WHERE dps.ComplianceYear = @ComplianceYear
-      AND rp.Removed = 0
+		INNER JOIN
+		(
+			-- Subquery to get the first submission date for each producer (unchanged)
+			SELECT
+				PS.RegisteredProducerId,
+				MIN(DPSH_FIRST.SubmittedDate) AS SubmittedDate
+			FROM
+				[Producer].[DirectProducerSubmission] PS
+			INNER JOIN [Producer].[DirectProducerSubmissionHistory] DPSH_FIRST ON DPSH_FIRST.DirectProducerSubmissionId = PS.Id
+			INNER JOIN [Producer].[RegisteredProducer] RP_FIRST ON RP_FIRST.Id = PS.RegisteredProducerId
+			WHERE
+				DPSH_FIRST.SubmittedDate IS NOT NULL AND (RP_FIRST.Removed = 0)
+			GROUP BY
+				PS.RegisteredProducerId
+		) firstSubmitted ON DPS.RegisteredProducerId = firstSubmitted.RegisteredProducerId
+WHERE
+	DPS.ComplianceYear = @ComplianceYear AND
+	RP.Removed = 0 AND
+	DPS.[Status] IN (2, 3) AND -- ('Submitted', 'Returned')
+	O.OrganisationType = 1 -- Registered company
 
 ORDER BY
-    IsDirectProducer,
-    S.SchemeName,
-    ProducerName
-
+	IsDirectProducer,
+	S.SchemeName,
+	ProducerName
 END
-GO


### PR DESCRIPTION
Update [Producer].[spgProducerPublicRegisterCSVDataByComplianceYear] to use per-compliance-year values from DirectProducerSubmissionHistory for direct registrants' company, trading name, business address, and authorized representative fields. This ensures accurate export for each compliance year, especially for migrated/legacy records. The scheme producer query is unchanged. Also adds explicit filtering for direct registrants by submission status and organization type, and improves code clarity and documentation.