### PR TITLE
Make AddReturnSchemeHandler idempotent; prevent form resubmits

### DIFF
--- a/src/EA.Weee.RequestHandlers/AatfReturn/AddReturnSchemeHandler.cs
+++ b/src/EA.Weee.RequestHandlers/AatfReturn/AddReturnSchemeHandler.cs
@@ -7,6 +7,7 @@
     using EA.Weee.Requests.AatfReturn;
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading.Tasks;
 
     public class AddReturnSchemeHandler : IRequestHandler<AddReturnScheme, List<Guid>>
@@ -29,11 +30,28 @@
             authorization.EnsureCanAccessExternalArea();
 
             var @return = await returnDataAccess.GetById(message.ReturnId);
+
+            // Make the handler idempotent: duplicate or concurrent submissions
+            // (double-click, browser retry, second tab) must not create
+            // duplicate ReturnScheme rows for the same (ReturnId, SchemeId).
+            var existingSchemes = await returnSchemeDataAccess.GetSelectedSchemesByReturnId(message.ReturnId);
+            var existingSchemeIds = new HashSet<Guid>(existingSchemes.Select(rs => rs.SchemeId));
+
             var returnSchemes = new List<ReturnScheme>();
-            foreach (var schemeId in message.SchemeIds)
+            foreach (var schemeId in message.SchemeIds.Distinct())
             {
+                if (existingSchemeIds.Contains(schemeId))
+                {
+                    continue;
+                }
+
                 var scheme = await schemeDataAccess.GetSchemeOrDefault(schemeId);
                 returnSchemes.Add(new ReturnScheme(scheme, @return));
+            }
+
+            if (returnSchemes.Count == 0)
+            {
+                return new List<Guid>();
             }
 
             return await returnSchemeDataAccess.Submit(returnSchemes);

--- a/src/EA.Weee.Web/Scripts/weee-application.js
+++ b/src/EA.Weee.Web/Scripts/weee-application.js
@@ -38,6 +38,16 @@
         return disableButtonFor1Second($(this));
     });
 
+    // Track which submit control the user actually activated so that when we
+    // disable the buttons after the first submit (below) we only re-post the
+    // name/value of the button the user clicked - matching native browser
+    // behaviour on multi-submit forms.
+    var lastClickedSubmit = null;
+
+    $(document).on('click', 'button[type=submit], input[type=submit]', function () {
+        lastClickedSubmit = this;
+    });
+
     // Prevent multiple submissions of the same form. The per-button debounce
     // above only protects against repeated mouse clicks on the same button;
     // this handler additionally covers:
@@ -48,9 +58,9 @@
     // The first submit is allowed through and the submit buttons inside the
     // form are disabled (with aria-disabled for assistive tech) so the user
     // gets immediate visual feedback. Because a disabled control's value is
-    // not posted, a hidden input mirroring each submit button's name/value
-    // is appended before disabling so any server-side code that branches on
-    // the button name continues to receive it.
+    // not posted, a hidden input mirroring the clicked submit button's
+    // name/value is appended before disabling so server-side code that
+    // branches on the button name continues to receive it.
     $(document).on('submit', 'form', function () {
         var $form = $(this);
 
@@ -59,6 +69,27 @@
         }
         $form.data('weeeSubmitted', true);
 
+        // Resolve the submitter: the button the user clicked, or - for
+        // Enter-key / programmatic submits - the first enabled submit button
+        // in this form, which is what the browser would have used implicitly.
+        var submitter = null;
+
+        if (lastClickedSubmit && $.contains(this, lastClickedSubmit)) {
+            submitter = lastClickedSubmit;
+        } else {
+            submitter = $form.find('button[type=submit], input[type=submit]')
+                             .filter(':not(:disabled)')
+                             .get(0) || null;
+        }
+
+        if (submitter && submitter.name) {
+            $('<input>', {
+                type: 'hidden',
+                name: submitter.name,
+                value: $(submitter).val()
+            }).appendTo($form);
+        }
+
         $form.find('button[type=submit], input[type=submit]').each(function () {
             var $btn = $(this);
 
@@ -66,17 +97,12 @@
                 return;
             }
 
-            var name = $btn.attr('name');
-            if (name) {
-                $('<input>', {
-                    type: 'hidden',
-                    name: name,
-                    value: $btn.val()
-                }).appendTo($form);
-            }
-
             $btn.prop('disabled', true).attr('aria-disabled', 'true');
         });
+
+        // Clear the tracked submitter so a later form submission on the same
+        // page cannot inherit it.
+        lastClickedSubmit = null;
     });
 
     // There is a bug with jQuery UI autocomplete whereby the content

--- a/src/EA.Weee.Web/Scripts/weee-application.js
+++ b/src/EA.Weee.Web/Scripts/weee-application.js
@@ -38,6 +38,47 @@
         return disableButtonFor1Second($(this));
     });
 
+    // Prevent multiple submissions of the same form. The per-button debounce
+    // above only protects against repeated mouse clicks on the same button;
+    // this handler additionally covers:
+    //   - Enter-key submissions from inside an input (no button click fires)
+    //   - Programmatic submits via $form.submit()
+    //   - Any subsequent submit attempt of the same form instance
+    //
+    // The first submit is allowed through and the submit buttons inside the
+    // form are disabled (with aria-disabled for assistive tech) so the user
+    // gets immediate visual feedback. Because a disabled control's value is
+    // not posted, a hidden input mirroring each submit button's name/value
+    // is appended before disabling so any server-side code that branches on
+    // the button name continues to receive it.
+    $(document).on('submit', 'form', function () {
+        var $form = $(this);
+
+        if ($form.data('weeeSubmitted')) {
+            return false;
+        }
+        $form.data('weeeSubmitted', true);
+
+        $form.find('button[type=submit], input[type=submit]').each(function () {
+            var $btn = $(this);
+
+            if ($btn.is(':disabled')) {
+                return;
+            }
+
+            var name = $btn.attr('name');
+            if (name) {
+                $('<input>', {
+                    type: 'hidden',
+                    name: name,
+                    value: $btn.val()
+                }).appendTo($form);
+            }
+
+            $btn.prop('disabled', true).attr('aria-disabled', 'true');
+        });
+    });
+
     // There is a bug with jQuery UI autocomplete whereby the content
     // of the drop-down list has the incorrect width. a fix for this
     // is to override the implementation of "_resizeMenu" to correctly


### PR DESCRIPTION

The AddReturnSchemeHandler was updated to ensure idempotency by:
- Avoiding duplicate ReturnScheme rows for the same (ReturnId, SchemeId).
- Filtering out duplicate SchemeIds from input.
- Skipping creation of ReturnScheme objects for existing SchemeIds.
- Returning an empty list if no new ReturnScheme objects are created.

In weee-application.js, added logic to prevent multiple form submissions:
- Handles Enter-key submissions, programmatic submits, and retries.
- Disables submit buttons after the first submission with `aria-disabled`.
- Appends hidden inputs to preserve button name/value pairs for the server.

<img width="2455" height="797" alt="image" src="https://github.com/user-attachments/assets/357601f4-2468-4492-8404-8d38473d469e" />
<img width="526" height="218" alt="image" src="https://github.com/user-attachments/assets/30b4971b-d062-484b-ae88-aeeb33a92d67" />
