### PR TITLE
Update stored procedure for producer data retrieval

### DIFF
--- a/src/EA.Weee.Database/EA.Weee.Database.csproj
+++ b/src/EA.Weee.Database/EA.Weee.Database.csproj
@@ -501,6 +501,7 @@
     <Content Include="scripts\Update\Release 8\Sprint7\20260529-1327-Alter-Identity-AspNetUsers-Table.sql" />
     <Content Include="scripts\Update\Release 8\Sprint7\20260515-1555-Alter-Producer-spgProducerPublicRegisterCSVDataByComplianceYear.sql" />
     <Content Include="scripts\Update\Release 8\Sprint7\20260515-1618-Insert-ChargeBandAmountFor2027.sql" />
+    <Content Include="scripts\Update\Release 8\Sprint7\20260715-1400-alter-Producer-spgProducerEeeCSVData.sql" />
     <None Include="rebuild-development.bat" />
     <Content Include="scripts\Update\Release 4\20220311-1315-sent-on-for-treatment-report.sql" />
     <Content Include="scripts\Update\Release 4\20220923-1751-remove-weeesenton-table-relation.sql" />

--- a/src/EA.Weee.Database/EA.Weee.Database.csproj
+++ b/src/EA.Weee.Database/EA.Weee.Database.csproj
@@ -55,6 +55,7 @@
   <ItemGroup>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Content Include="scripts\Update\Release 8\Sprint7\20260702-1544-Alter-Producer-spgCSVDataBySchemeComplianceYearAndAuthorisedAuthority.sql" />
     <Content Include="scripts\Update\Release 8\Sprint6\20260316-0900-Update-Lookup-OnlineMarketplaceCharge.sql" />
     <Content Include="scripts\Create\0001-Permissions-AppRole.sql" />
     <Content Include="Readme.txt" />

--- a/src/EA.Weee.Database/scripts/Update/Release 8/Sprint7/20260702-1544-Alter-Producer-spgCSVDataBySchemeComplianceYearAndAuthorisedAuthority.sql
+++ b/src/EA.Weee.Database/scripts/Update/Release 8/Sprint7/20260702-1544-Alter-Producer-spgCSVDataBySchemeComplianceYearAndAuthorisedAuthority.sql
@@ -1,0 +1,564 @@
+﻿/****** Object:  StoredProcedure [Producer].[spgCSVDataBySchemeComplianceYearAndAuthorisedAuthority]    Script Date: 03/07/2026 12:12:26 ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+-- Description:	This stored procedure is used to provide data by scheme compliance year and Authorised Authority
+-- Modified Date: 03/07/2026 [Fixed compliance year filtering and all data sources for direct registrants]
+-- =============================================================================================================
+
+ALTER PROCEDURE [Producer].[spgCSVDataBySchemeComplianceYearAndAuthorisedAuthority]
+	@ComplianceYear INT,
+	@IncludeRemovedProducer BIT,
+	@IncludeBrandNames BIT,
+	@SchemeId UNIQUEIDENTIFIER = NULL,
+	@CompetentAuthorityId UNIQUEIDENTIFIER = NULL,
+	@FilterByDirectRegistrant BIT = 0,
+	@FilterBySchemes BIT = 0
+AS
+BEGIN
+	SET NOCOUNT ON;
+
+	-- Main query to retrieve producer data
+	SELECT
+		CASE WHEN MU.IsSubmitted = 1 THEN 'Registered' ELSE NULL END AS 'RegistrationStatus',
+		NULL AS 'PaymentStatus',
+		NULL as 'PaymentReference',
+		NULL as 'PrimaryContactForename',
+		NULL as 'PrimaryContactSurname',
+		NULL as 'PrimaryContactPosition',
+		NULL as 'PrimaryContactTelephone',
+		NULL as 'PrimaryContactEmail',
+		NULL as 'PrimaryContactAddressLine1',
+		NULL as 'PrimaryContactAddressLine2',
+		NULL as 'PrimaryContactTown',
+		NULL as 'PrimaryContactCounty',
+		NULL as 'PrimaryContactPostcode',
+		NULL as 'PrimaryContactCountry',
+		NULL as 'SignatoryForename',
+		NULL as 'SignatorySurname',
+		NULL as 'SignatoryPosition',
+
+		-- Scheme Information
+		S.SchemeName,
+		S.ApprovalNumber,
+
+		-- Producer Information
+		PS.TradingName,
+		PBC.Name AS 'CompanyName',
+
+		(SELECT
+			CASE
+				WHEN (Partners.TotalPartners = 1)  THEN 'Sole Trader or Individual'
+				WHEN (Partners.TotalPartners >= 2) THEN 'Partnership'
+				ELSE 'Registered Company'
+			END 
+		FROM
+		(SELECT Count(PP.Name) as TotalPartners
+			FROM [Producer].[Partner] PP
+			WHERE PBP.Id = PP.PartnershipId) Partners
+		)AS 'ProducerType',
+
+		CASE
+			WHEN PBC.Name IS NULL THEN PBP.Name
+			ELSE PBC.Name
+		END AS 'ProducerName',
+		RP.ProducerRegistrationNumber AS 'PRN',
+		P_First.SubmittedDate AS 'DateRegistered',
+		MU.SubmittedDate AS 'DateAmended',
+
+		-- Business Details
+		SICCODES.SICCode as 'SICCODES',
+		PS.VATRegistered,
+		PS.AnnualTurnover,
+		CASE PS.AnnualTurnoverBandType
+			WHEN 0 THEN 'Less than or equal to one million pounds'
+			WHEN 1 THEN 'Greater than one million pounds'
+			ELSE ''
+		END AS 'AnnualTurnoverBandType',
+        CASE PS.EEEPlacedOnMarketBandType
+            WHEN 0 THEN 'More than or equal to 5T EEE placed on market'
+            WHEN 1 THEN 'Less than 5T EEE placed on market'
+            WHEN 2 THEN 'Both'
+            ELSE ''
+        END AS 'EEEPlacedOnMarketBandType',
+        PS.ObligationType AS 'ObligationType',
+        CASE CBA.ChargeBand
+            WHEN 0 THEN 'A'
+            WHEN 1 THEN 'B'
+            WHEN 2 THEN 'C'
+            WHEN 3 THEN 'D'
+            WHEN 4 THEN 'E'
+            WHEN 5 THEN 'A2'
+            WHEN 6 THEN 'C2'
+            WHEN 7 THEN 'D2'
+            WHEN 8 THEN 'D3'
+            ELSE ''
+        END AS 'ChargeBandType',
+        CASE PS.SellingTechniqueType
+            WHEN 0 THEN 'Direct Selling to End User'
+            WHEN 1 THEN 'Indirect Selling to End User'
+            WHEN 2 THEN 'Both Direct and Indirect Selling to End User'
+            WHEN 3 THEN 'Online marketplace'
+            ELSE ''
+        END AS 'SellingTechniqueType',
+        PS.CeaseToExist,
+
+        -- Correspondence for Notices Contact Details
+        CFNC.Title as 'CNTitle',
+        CFNC.Forename as 'CNForename',
+        CFNC.Surname as 'CNSurname',
+        CFNC.Telephone as 'CNTelephone',
+        CFNC.Mobile as 'CNMobile',
+        CFNC.Fax as 'CNFax',
+        CFNC.Email as 'CNEmail',
+        CFNC_A.PrimaryName as 'CNPrimaryName',
+        CFNC_A.SecondaryName as 'CNSecondaryName',
+        CFNC_A.Street as 'CNStreet',
+        CFNC_A.Town as 'CNTown',
+        CFNC_A.Locality as 'CNLocality',
+        CFNC_A.AdministrativeArea as 'CNAdministrativeArea',
+        CFNC_A.PostCode as 'CNPostcode',
+        CFNC_A_C.Name as 'CNCountry',
+
+        -- Registered Office Details
+        PBC.CompanyNumber,
+        ROC.Title as 'CompanyContactTitle',
+        ROC.Forename as 'CompanyContactForename',
+        ROC.Surname as 'CompanyContactSurname',
+        ROC.Telephone as 'CompanyContactTelephone',
+        ROC.Mobile as 'CompanyContactMobile',
+        ROC.Fax as 'CompanyContactFax',
+        ROC.Email as 'CompanyContactEmail',
+        ROC_A.PrimaryName as 'CompanyContactPrimaryName',
+        ROC_A.SecondaryName as 'CompanyContactSecondaryName',
+        ROC_A.Street as 'CompanyContactStreet',
+        ROC_A.Town as 'CompanyContactTown',
+        ROC_A.Locality as 'CompanyContactLocality',
+        ROC_A.AdministrativeArea as 'CompanyContactAdministrativeArea',
+        ROC_A.PostCode as 'CompanyContactPostcode',
+        ROC_A_C.Name as 'CompanyContactCountry',
+
+        -- Principal Place of Business Details
+        Partners.Partners,
+        PPOB.Title as 'PPOBContactTitle',
+        PPOB.Forename as 'PPOBContactForename',
+        PPOB.Surname as 'PPOBContactSurname',
+        PPOB.Telephone as 'PPOBContactTelephone',
+        PPOB.Mobile as 'PPOBContactMobile',
+        PPOB.Fax as 'PPOBContactFax',
+        PPOB.Email as 'PPOBContactEmail',
+        NULL as 'PPOBContactWebsite',
+        PPOB_A.PrimaryName as 'PPOBContactPrimaryName',
+        PPOB_A.SecondaryName as 'PPOBContactSecondaryName',
+        PPOB_A.Street as 'PPOBContactStreet',
+        PPOB_A.Town as 'PPOBContactTown',
+        PPOB_A.Locality as 'PPOBContactLocality',
+        PPOB_A.AdministrativeArea as 'PPOBContactAdministrativeArea',
+        PPOB_A.PostCode as 'PPOBContactPostcode',
+        PPOB_A_C.Name as 'PPOBContactCountry',
+
+        -- Overseas Contact Details
+        AR.OverseasProducerName as 'OverseasProducerName',
+        OC.Title as 'OverseasContactTitle',
+        OC.Forename as 'OverseasContactForename',
+        OC.Surname as 'OverseasContactSurname',
+        OC.Telephone as 'OverseasContactTelephone',
+        OC.Mobile as 'OverseasContactMobile',
+        OC.Fax as 'OverseasContactFax',
+        OC.Email as 'OverseasContactEmail',
+        OC_A.PrimaryName as 'OverseasContactPrimaryName',
+        OC_A.SecondaryName as 'OverseasContactSecondaryName',
+        OC_A.Street as 'OverseasContactStreet',
+        OC_A.Town as 'OverseasContactTown',
+        OC_A.Locality as 'OverseasContactLocality',
+        OC_A.AdministrativeArea as 'OverseasContactAdministrativeArea',
+        OC_A.PostCode as 'OverseasContactPostcode',
+        OC_A_C.Name as 'OverseasContactCountry',
+
+        -- Removal Status
+        CASE RP.Removed
+            WHEN 1 THEN 'Yes'
+            WHEN 0 THEN 'No'
+        END AS 'RemovedFromScheme',
+
+        -- Brand Names (if requested)
+        CASE @IncludeBrandNames
+            WHEN 1 THEN
+                (SELECT STUFF((SELECT '; ' + BN.Name
+                FROM [Producer].[BrandName] BN
+                WHERE BN.ProducerSubmissionId = PS.Id
+                FOR XML PATH(''), TYPE)
+                .value('.', 'NVARCHAR(MAX)')
+                , 1, 2, ''))
+            WHEN 0 THEN NULL
+        END AS 'BrandNames',
+		0 AS IsDirectProducer
+
+    FROM
+        [Producer].[RegisteredProducer] RP
+    INNER JOIN
+        [Producer].[ProducerSubmission] PS ON RP.[CurrentSubmissionId] = PS.[Id]
+    INNER JOIN
+        [PCS].[MemberUpload] MU ON PS.MemberUploadId = MU.Id
+    INNER JOIN
+        [Pcs].[Scheme] S ON RP.SchemeId = S.Id
+    INNER JOIN
+        [Lookup].[ChargeBandAmount] CBA ON PS.[ChargeBandAmountId] = CBA.[Id]
+    LEFT JOIN
+        [Producer].[AuthorisedRepresentative] AR ON PS.AuthorisedRepresentativeId = AR.Id
+    LEFT JOIN
+        [Producer].[Contact] OC ON AR.OverseasContactId = OC.Id
+    LEFT JOIN
+        [Producer].[Address] OC_A ON OC.AddressId = OC_A.Id
+    LEFT JOIN
+        [Lookup].[Country] OC_A_C ON OC_A.CountryId = OC_A_C.Id
+    LEFT JOIN
+        [Producer].[Business] PB ON PS.ProducerBusinessId = PB.Id
+    LEFT JOIN
+        [Producer].[Contact] CFNC ON PB.CorrespondentForNoticesContactId = CFNC.Id
+    LEFT JOIN
+        [Producer].[Address] CFNC_A ON CFNC.AddressId = CFNC_A.Id
+    LEFT JOIN
+        [Lookup].[Country] CFNC_A_C ON CFNC_A.CountryId = CFNC_A_C.Id
+    LEFT JOIN
+        [Producer].[Company] PBC ON PB.CompanyId = PBC.Id
+    LEFT JOIN
+        [Producer].[Contact] ROC ON PBC.RegisteredOfficeContactId = ROC.Id
+    LEFT JOIN
+        [Producer].[Address] ROC_A ON ROC.AddressId = ROC_A.Id
+    LEFT JOIN
+        [Lookup].[Country] ROC_A_C ON ROC_A.CountryId = ROC_A_C.Id
+    LEFT JOIN
+        [Producer].[Partnership] PBP ON PB.PartnershipId = PBP.Id
+    LEFT JOIN
+        [Producer].[Contact] PPOB ON PBP.PrincipalPlaceOfBusinessId = PPOB.Id
+    LEFT JOIN
+        [Producer].[Address] PPOB_A ON PPOB.AddressId = PPOB_A.Id
+    LEFT JOIN
+        [Lookup].[Country] PPOB_A_C ON PPOB_A.CountryId = PPOB_A_C.Id
+    INNER JOIN
+    (
+        -- Subquery to get the first submission date for each producer
+        SELECT
+            MU.ComplianceYear,
+            PS.RegisteredProducerId,
+            MU.SubmittedDate,
+            ROW_NUMBER() OVER (
+                PARTITION BY PS.RegisteredProducerId
+                ORDER BY PS.UpdatedDate
+            ) AS RowNumber
+        FROM
+            Producer.ProducerSubmission PS
+        INNER JOIN
+            PCS.MemberUpload MU ON PS.MemberUploadId = MU.Id
+        INNER JOIN
+            Producer.RegisteredProducer RP ON PS.RegisteredProducerId = RP.Id
+        WHERE
+            MU.IsSubmitted = 1
+            AND (@IncludeRemovedProducer = 1 OR RP.Removed = 0)
+    ) P_First ON PS.RegisteredProducerId = P_First.RegisteredProducerId AND P_First.RowNumber = 1
+    LEFT JOIN
+    (
+        -- Subquery to concatenate SIC codes
+        SELECT DISTINCT
+            PS.Id,
+            STUFF((SELECT distinct '; ' + SIC.Name
+                FROM [Producer].[SICCode] SIC
+                WHERE PS.Id = SIC.ProducerSubmissionId
+                FOR XML PATH(''), TYPE
+                ).value('.', 'NVARCHAR(MAX)')
+                ,1,2,'') SICCode
+        FROM
+            [Producer].[ProducerSubmission] PS
+    ) SICCODES ON PS.Id = SICCODES.Id
+    LEFT JOIN
+    (
+        -- Subquery to concatenate partner names
+        SELECT DISTINCT
+            P.Id,
+            STUFF((SELECT distinct '; ' + PP.Name
+                FROM [Producer].[Partner] PP
+                WHERE P.Id = PP.PartnershipId
+                FOR XML PATH(''), TYPE
+                ).value('.', 'NVARCHAR(MAX)')
+                ,1,2,'') Partners
+        FROM
+            [Producer].[Partnership] P
+    ) Partners ON PBP.[Id] = Partners.[Id]
+    WHERE
+        RP.ComplianceYear = @ComplianceYear
+        AND (@SchemeId IS NULL OR RP.SchemeId = @SchemeId)
+        AND (@CompetentAuthorityId IS NULL OR S.CompetentAuthorityId = @CompetentAuthorityId)
+        AND (@IncludeRemovedProducer = 1 OR RP.Removed = 0)
+        AND @FilterByDirectRegistrant = 0
+        AND (@SchemeId IS NOT NULL OR @FilterBySchemes = 1 OR (@FilterBySchemes = 0 AND @FilterByDirectRegistrant = 0))
+
+	UNION ALL
+
+	-- Query for the direct registrant dataset
+	SELECT
+		CASE
+			WHEN ((dps.[Status] = 3 AND dps.PaymentFinished = 1) AND (dps.FinalPaymentSessionId IS NOT NULL OR dps.ManualPaymentReceivedDate IS NOT NULL)) THEN 'Returned'
+			WHEN ((dps.[Status] = 2 AND dps.PaymentFinished = 1) AND (dps.FinalPaymentSessionId IS NOT NULL OR dps.ManualPaymentReceivedDate IS NOT NULL)) THEN 'Registered'
+			WHEN ((dps.[Status] = 2 AND dps.PaymentFinished = 0) AND (dps.FinalPaymentSessionId IS NULL OR dps.ManualPaymentReceivedDate IS NULL)) THEN 'Submitted'
+			ELSE ''
+		END AS 'RegistrationStatus',
+
+		CASE
+			WHEN dps.PaymentFinished = 1 AND dps.FinalPaymentSessionId IS NOT NULL THEN 'Paid'
+			WHEN dps.PaymentFinished = 1 AND dps.ManualPaymentReceivedDate IS NOT NULL THEN 'Paid'
+			ELSE 'Not Paid'
+		END AS 'PaymentStatus',
+
+		paySession.[PaymentReference] as 'PaymentReference',
+		oc.FirstName as 'PrimaryContactForename',
+		oc.LastName as 'PrimaryContactSurname',
+		oc.Position as 'PrimaryContactPosition',
+		ad.Telephone as 'PrimaryContactTelephone',
+		ad.Email as 'PrimaryContactEmail ',
+		ad.Address1 as 'PrimaryContactAddressLine1',
+		ad.Address2 as 'PrimaryContactAddressLine2',
+		ad.TownOrCity as 'PrimaryContactTown',
+		ad.CountyOrRegion as 'PrimaryContactCounty',
+		ad.Postcode as 'PrimaryContactPostcode',
+		contactCountry.[Name] as 'PrimaryContactCountry',
+		signatory.Forename as 'SignatoryForename',
+		signatory.Surname as 'SignatorySurname',
+		signatory.Position as 'SignatoryPosition',
+
+		-- Scheme Information
+		'Direct registrant' AS SchemeName,
+		NULL AS ApprovalNumber,
+
+		-- Producer Information
+		o.[TradingName] AS 'TradingName',
+		dpsh.[CompanyName] AS 'CompanyName',
+		CASE
+			WHEN o.OrganisationType = 1 THEN 'Registered company'
+			WHEN o.OrganisationType IN (2,4) THEN 'Partnership'
+			WHEN o.OrganisationType = 3 THEN 'Sole trader or individual'
+		END AS 'ProducerType',
+		dpsh.[CompanyName] AS 'ProducerName',
+		rp.ProducerRegistrationNumber AS 'PRN',
+
+		CASE
+			WHEN dps.PaymentFinished = 1 AND dps.FinalPaymentSessionId IS NOT NULL THEN paySession.UpdatedAt
+			WHEN dps.PaymentFinished = 1 AND dps.ManualPaymentReceivedDate IS NOT NULL THEN dps.ManualPaymentReceivedDate
+			ELSE NULL
+		END AS 'DateRegistered',
+
+		dpsh.SubmittedDate AS 'DateAmended',
+
+		-- Business Details
+		NULL AS 'SICCODES',
+		NULL AS VATRegistered,
+		NULL AS AnnualTurnover,
+		NULL AS 'AnnualTurnoverBandType',
+		'Less than 5T EEE placed on market' AS 'EEEPlacedOnMarketBandType',
+		dbo.GetObligationType(eorv.Id) AS 'ObligationType',
+		NULL 'ChargeBandType',
+		CASE dpsh.SellingTechniqueType
+			WHEN 0 THEN 'Direct Selling to End User'
+			WHEN 1 THEN 'Indirect Selling to End User'
+			WHEN 2 THEN 'Both Direct and Indirect Selling to End User'
+			WHEN 3 THEN 'Online marketplace'
+			ELSE ''
+		END AS 'SellingTechniqueType',
+		NULL AS CeaseToExist,
+
+		-- Correspondence for Notices Contact Details
+		NULL as 'CNTitle',
+		NULL as 'CNForename',
+		NULL as 'CNSurname',
+		serviceAddress.Telephone as 'CNTelephone',
+		NULL as 'CNMobile',
+		NULL as 'CNFax',
+		serviceAddress.Email as 'CNEmail',
+		serviceAddress.Address1 as 'CNPrimaryName',
+		NULL as 'CNSecondaryName',
+		serviceAddress.Address2 as 'CNStreet',
+		serviceAddress.TownOrCity as 'CNTown',
+		serviceAddress.CountyOrRegion as 'CNLocality',
+		NULL as 'CNAdministrativeArea',
+		serviceAddress.PostCode as 'CNPostcode',
+		serviceAddressCountry.Name as 'CNCountry',
+
+		-- Registered Office Details
+		o.CompanyRegistrationNumber AS 'CompanyNumber',
+		NULL as 'CompanyContactTitle',
+		NULL as 'CompanyContactForename',
+		NULL as 'CompanyContactSurname',
+		businessAddress.Telephone as 'CompanyContactTelephone',
+		NULL as 'CompanyContactMobile',
+		businessAddress.Fax as 'CompanyContactFax',
+		businessAddress.Email as 'CompanyContactEmail',
+		businessAddress.Address1 as 'CompanyContactPrimaryName',
+		NULL as 'CompanyContactSecondaryName',
+		businessAddress.Address2 as 'CompanyContactStreet',
+		businessAddress.TownOrCity as 'CompanyContactTown',
+		businessAddress.CountyOrRegion as 'CompanyContactLocality',
+		NULL as 'CompanyContactAdministrativeArea',
+		businessAddress.PostCode as 'CompanyContactPostcode',
+		businessCountry.Name as 'CompanyContactCountry',
+
+		-- Principal Place of Business Details
+		additionalDetails.AllFullNames AS 'Partners',
+		NULL as 'PPOBContactTitle',
+		NULL as 'PPOBContactForename',
+		NULL as 'PPOBContactSurname',
+		NULL as 'PPOBContactTelephone',
+		NULL as 'PPOBContactMobile',
+		NULL as 'PPOBContactFax',
+		ad.Email as 'PPOBContactEmail',
+		CASE 
+			WHEN ad.WebAddress IS NOT NULL THEN ad.WebAddress
+			WHEN businessAddress.WebAddress IS NOT NULL THEN businessAddress.WebAddress
+			ELSE ''
+		END AS 'PPOBContactWebsite',
+		NULL as 'PPOBContactPrimaryName',
+		NULL as 'PPOBContactSecondaryName',
+		NULL as 'PPOBContactStreet',
+		NULL as 'PPOBContactTown',
+		NULL as 'PPOBContactLocality',
+		NULL as 'PPOBContactAdministrativeArea',
+		NULL as 'PPOBContactPostcode',
+		NULL as 'PPOBContactCountry',
+
+		-- Overseas Contact Details / Auth rep
+		ap.OverseasProducerName as 'OverseasProducerName',
+		pc.Title as 'OverseasContactTitle',
+		pc.Forename as 'OverseasContactForename',
+		pc.Surname as 'OverseasContactSurname',
+		pc.Telephone as 'OverseasContactTelephone',
+		pc.Mobile as 'OverseasContactMobile',
+		pc.Fax as 'OverseasContactFax',
+		pc.Email as 'OverseasContactEmail',
+		pa.PrimaryName as 'OverseasContactPrimaryName',
+		pa.SecondaryName as 'OverseasContactSecondaryName',
+		pa.Street as 'OverseasContactStreet',
+		pa.Town as 'OverseasContactTown',
+		pa.Locality as 'OverseasContactLocality',
+		pa.AdministrativeArea as 'OverseasContactAdministrativeArea',
+		pa.PostCode as 'OverseasContactPostcode',
+		ac.Name as 'OverseasContactCountry',
+
+		-- Removal Status
+		CASE RP.Removed
+			WHEN 1 THEN 'Yes'
+			WHEN 0 THEN 'No'
+		END AS 'RemovedFromScheme',
+
+		-- Brand Names (if requested)
+		CASE @IncludeBrandNames
+			WHEN 1 THEN
+				ISNULL(NULLIF(
+					(SELECT STUFF((SELECT '; ' + BN.Name
+					FROM
+					[Producer].[DirectRegistrant] drb
+					INNER JOIN [Producer].[BrandName] bn ON bn.Id = drb.BrandNameId
+					WHERE drb.Id = dr.Id
+					FOR XML PATH(''), TYPE)
+					.value('.', 'NVARCHAR(MAX)')
+					, 1, 2, '')), ''), '')
+			WHEN 0 THEN ''
+		END AS 'BrandNames',
+		1 AS IsDirectProducer
+
+	FROM
+		[Producer].[DirectProducerSubmission] dps
+		INNER JOIN [Producer].[DirectRegistrant] dr ON dr.Id = dps.DirectRegistrantId
+		INNER JOIN [Organisation].[Organisation] o ON o.Id = dr.OrganisationId
+		INNER JOIN [Producer].[RegisteredProducer] rp ON dps.RegisteredProducerId = rp.Id AND dps.ComplianceYear = @ComplianceYear
+		INNER JOIN (
+                    SELECT
+                        dpsh.Id,
+                        dpsh.DirectProducerSubmissionId,
+						ROW_NUMBER() OVER (PARTITION BY dpsh.DirectProducerSubmissionId ORDER BY dpsh.SubmittedDate DESC) as rn
+                    FROM
+                        [Producer].[DirectProducerSubmissionHistory] dpsh
+                        INNER JOIN [Producer].[DirectProducerSubmission] ps ON dpsh.DirectProducerSubmissionId = ps.Id
+                        INNER JOIN [Producer].[RegisteredProducer] rp ON ps.RegisteredProducerId = rp.Id
+                    WHERE
+                        dpsh.SubmittedDate IS NOT NULL
+						AND ps.ComplianceYear = @ComplianceYear
+                        AND (@IncludeRemovedProducer = 1 OR RP.Removed = 0)
+                    ) latest_submission ON latest_submission.DirectProducerSubmissionId = dps.Id AND latest_submission.rn = 1
+		INNER JOIN [Producer].[DirectProducerSubmissionHistory] dpsh ON dpsh.Id = latest_submission.Id
+		
+		-- Contact and Address from submission history (year-specific data)
+		LEFT JOIN [Organisation].[Contact] oc ON oc.Id = dpsh.ContactId
+		LEFT JOIN [Organisation].[Address] ad ON ad.Id = dpsh.ContactAddressId
+		LEFT JOIN [Lookup].[Country] contactCountry ON contactCountry.Id = ad.CountryId
+		
+		-- Business Address from submission history (year-specific)
+		LEFT JOIN [Organisation].[Address] businessAddress ON businessAddress.Id = dpsh.BusinessAddressId
+		LEFT JOIN [Lookup].[Country] businessCountry ON businessCountry.Id = businessAddress.CountryId
+		
+		LEFT JOIN [Producer].[PaymentSession] paySession ON paySession.Id = dps.FinalPaymentSessionId
+		LEFT JOIN [Organisation].[Address] serviceAddress ON serviceAddress.Id = dpsh.ServiceOfNoticeAddressId
+		LEFT JOIN [Lookup].[Country] serviceAddressCountry ON serviceAddressCountry.Id = serviceAddress.CountryId
+		LEFT JOIN [PCS].[EeeOutputReturnVersion] eorv ON eorv.Id = dpsh.EeeOutputReturnVersionId
+		
+		-- AuthorisedRepresentative from submission history (year-specific)
+		LEFT JOIN [Producer].[AuthorisedRepresentative] ap ON ap.Id = dpsh.AuthorisedRepresentativeId
+		LEFT JOIN [Producer].[Contact] pc ON pc.Id = ap.OverseasContactId
+		LEFT JOIN [Producer].[Address] pa ON pa.Id = pc.AddressId
+		LEFT JOIN [Lookup].[Country] ac ON ac.Id = pa.CountryId
+		
+		LEFT JOIN(
+					SELECT  
+						oc.FirstName as 'Forename',
+						oc.LastName as 'Surname',
+						oc.Position as 'Position',
+						pds.Id as 'DirectProducerSubmissionId'
+					FROM [Producer].[DirectProducerSubmission] pds
+					LEFT JOIN [Producer].[DirectProducerSubmissionHistory] psh on psh.Id = pds.CurrentSubmissionId
+					LEFT JOIN [Organisation].[Contact] oc on oc.id = psh.AppropriateSignatoryId	
+					WHERE pds.ComplianceYear = @ComplianceYear
+				) signatory on signatory.DirectProducerSubmissionId = dps.Id
+	INNER JOIN
+		(
+			-- Subquery to get the first submission date for each producer
+			SELECT
+                ps.RegisteredProducerId,
+                MIN(dpsh.SubmittedDate) AS SubmittedDate
+            FROM
+                [Producer].[DirectProducerSubmission] ps
+                INNER JOIN [Producer].[DirectProducerSubmissionHistory] dpsh ON dpsh.DirectProducerSubmissionId = ps.Id
+                INNER JOIN [Producer].[RegisteredProducer] rp ON ps.RegisteredProducerId = rp.Id
+            WHERE
+                dpsh.SubmittedDate IS NOT NULL
+				AND ps.ComplianceYear = @ComplianceYear
+                AND (@IncludeRemovedProducer = 1 OR RP.Removed = 0)
+            GROUP BY
+                ps.RegisteredProducerId
+		) firstSubmitted ON dps.RegisteredProducerId = firstSubmitted.RegisteredProducerId
+		LEFT JOIN
+		(
+			 SELECT
+				DirectRegistrantId,
+				STUFF((
+					SELECT '; ' + FirstName + ' ' + LastName
+					FROM [Organisation].AdditionalCompanyDetails acd2
+					WHERE acd2.DirectRegistrantId = acd1.DirectRegistrantId
+					FOR XML PATH(''), TYPE).value('.', 'NVARCHAR(MAX)'), 1, 2, '') AS AllFullNames
+			FROM
+				[Organisation].AdditionalCompanyDetails acd1
+			GROUP BY
+				DirectRegistrantId
+		) additionalDetails ON dr.Id = additionalDetails.DirectRegistrantId
+
+	
+	WHERE
+		(@IncludeRemovedProducer = 1 OR rp.Removed = 0) AND
+		dps.ComplianceYear = @ComplianceYear AND
+		 @SchemeId IS NULL AND
+		(@FilterByDirectRegistrant = 1 OR (@FilterBySchemes = 0 AND @FilterByDirectRegistrant = 0))
+
+	ORDER BY
+		IsDirectProducer,
+		S.SchemeName,
+		ProducerName;
+END
+GO

--- a/src/EA.Weee.Database/scripts/Update/Release 8/Sprint7/20260715-1400-alter-Producer-spgProducerEeeCSVData.sql
+++ b/src/EA.Weee.Database/scripts/Update/Release 8/Sprint7/20260715-1400-alter-Producer-spgProducerEeeCSVData.sql
@@ -1,0 +1,243 @@
+/****** Object:  StoredProcedure [Producer].[spgProducerEeeCsvData]    Script Date: 27/03/2025 10:08:45  ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+ALTER PROCEDURE [Producer].[spgProducerEeeCsvData]
+    @ComplianceYear INT,
+    @SchemeId UNIQUEIDENTIFIER = NULL,
+    @ObligationType NVARCHAR(4),
+    @FilterByDirectRegistrant BIT = 0,
+    @FilterBySchemes BIT = 0
+AS
+BEGIN
+    -- Create temporary table to store EEE data
+    CREATE TABLE #EEETable (
+        PRN NVARCHAR(100),
+        SchemeId UNIQUEIDENTIFIER,
+        ApprovalNumber NVARCHAR(50),
+        SchemeName NVARCHAR(255),
+        ProducerName NVARCHAR(255),
+        ProducerCountry NVARCHAR(100),
+        Quarter INT,
+        WeeeCategory INT,
+        Tonnage DECIMAL(18, 3),
+        IsDirectProducer BIT  -- New column to differentiate direct producers
+    )
+
+    -- Insert data into temporary table
+    INSERT INTO #EEETable
+    SELECT 
+        RP.ProducerRegistrationNumber AS 'PRN',
+        RP.SchemeId,
+        S.ApprovalNumber,
+        S.SchemeName,
+        COALESCE(PBC.Name, PBP.Name, '') AS 'ProducerName',
+        COALESCE(ROC_A_C.Name, PPOB_A_C.Name, '') AS 'ProducerCountry',
+        DR.Quarter,
+        EEOA.WeeeCategory,
+        EEOA.Tonnage,
+        0 AS IsDirectProducer  -- Not a direct producer
+    FROM [PCS].DataReturn DR
+    INNER JOIN [PCS].DataReturnVersion DRV ON DR.CurrentDataReturnVersionId = DRV.Id
+    INNER JOIN [PCS].[EeeOutputReturnVersion] EEORV ON DRV.EeeOutputReturnVersionId = EEORV.Id
+    INNER JOIN [PCS].[EeeOutputReturnVersionAmount] EEORVA ON EEORV.Id = EEORVA.EeeOutputReturnVersionId
+    INNER JOIN [PCS].[EeeOutputAmount] EEOA ON EEORVA.EeeOuputAmountId = EEOA.Id
+    INNER JOIN [Producer].[RegisteredProducer] RP ON EEOA.RegisteredProducerId = RP.Id
+    INNER JOIN [PCS].Scheme S ON RP.SchemeId = S.Id
+    INNER JOIN [Producer].[ProducerSubmission] PS ON RP.[CurrentSubmissionId] = PS.[Id]
+    LEFT JOIN [Producer].[Business] PB ON PS.ProducerBusinessId = PB.Id
+    LEFT JOIN [Producer].[Company] PBC ON PB.CompanyId = PBC.Id
+    LEFT JOIN [Producer].[Partnership] PBP ON PB.PartnershipId = PBP.Id
+    LEFT JOIN [Producer].[Contact] ROC 
+        INNER JOIN [Producer].[Address] ROC_A 
+            INNER JOIN [Lookup].[Country] ROC_A_C ON ROC_A.CountryId = ROC_A_C.Id     
+        ON ROC.AddressId = ROC_A.Id
+    ON PBC.RegisteredOfficeContactId = ROC.Id
+    LEFT JOIN [Producer].[Contact] PPOB 
+        INNER JOIN [Producer].[Address] PPOB_A 
+            INNER JOIN [Lookup].[Country] PPOB_A_C ON PPOB_A.CountryId = PPOB_A_C.Id   
+        ON PPOB.AddressId = PPOB_A.Id
+    ON PBP.PrincipalPlaceOfBusinessId = PPOB.Id
+    WHERE DR.ComplianceYear = @ComplianceYear
+        AND RP.Removed = 0
+        AND EEOA.ObligationType = @ObligationType
+        AND (@SchemeId IS NULL OR S.[Id] = @SchemeId)
+        AND (@FilterByDirectRegistrant = 0)
+		AND (@SchemeId IS NOT NULL OR @FilterBySchemes = 1 OR (@FilterBySchemes = 0 AND @FilterByDirectRegistrant = 0))
+
+    UNION ALL
+
+    -- Direct registrant query - updated to use year-specific submission history data
+    SELECT
+        RP.ProducerRegistrationNumber as 'PRN',
+        dr.Id AS 'SchemeId',
+        '' AS 'ApprovalNumber',
+        'Direct registrant' AS SchemeName,
+        -- Use submission history company name if available, otherwise fall back to organisation
+        COALESCE(
+            latest_submission.CompanyName,
+            DPSH_AR.OverseasProducerName,
+            o.[Name],
+            ''
+        ) AS 'ProducerName',
+        -- Use submission history business address country if available, otherwise fall back to organisation business address
+        COALESCE(
+            BA_C.Name,
+            OC.Name,
+            ''
+        ) AS 'ProducerCountry',
+        4 AS Quarter,
+        eoa.WeeeCategory,
+        eoa.Tonnage,
+        1 AS IsDirectProducer  -- This is a direct producer
+    FROM
+        [Producer].[DirectProducerSubmission] DPS
+		INNER JOIN [Producer].[DirectRegistrant] DR ON DR.Id = DPS.DirectRegistrantId
+		INNER JOIN [Organisation].[Organisation] O ON O.Id = DR.OrganisationId
+		-- Organisation business address (fallback)
+		LEFT JOIN [Organisation].[Address] OA ON OA.Id = O.BusinessAddressId
+		LEFT JOIN [Lookup].[Country] OC ON OC.Id = OA.CountryId
+		
+		INNER JOIN [Producer].[RegisteredProducer] RP ON DPS.RegisteredProducerId = RP.Id
+		
+		-- Get the latest submitted history for this compliance year to retrieve year-specific data
+		INNER JOIN (
+			SELECT 
+				DirectProducerSubmissionId,
+				EeeOutputReturnVersionId,
+				Id,
+				CompanyName,
+				BusinessAddressId,
+				AuthorisedRepresentativeId,
+				ROW_NUMBER() OVER (PARTITION BY DirectProducerSubmissionId ORDER BY SubmittedDate DESC) AS RowNum
+			FROM [Producer].[DirectProducerSubmissionHistory]
+			WHERE SubmittedDate IS NOT NULL
+		) DPSH ON DPSH.DirectProducerSubmissionId = DPS.Id AND DPSH.RowNum = 1
+		
+		-- Get the latest submission-specific data for the producer name and business address
+		OUTER APPLY (
+			SELECT TOP 1
+				ps.CompanyName,
+				ps.BusinessAddressId
+			FROM [Producer].[DirectProducerSubmissionHistory] ps
+			WHERE ps.DirectProducerSubmissionId = DPS.Id
+				AND ps.SubmittedDate IS NOT NULL
+			ORDER BY ps.SubmittedDate DESC
+		) latest_submission
+		
+		-- Year-specific business address from submission history
+		LEFT JOIN [Producer].[Address] BA ON BA.Id = latest_submission.BusinessAddressId
+		LEFT JOIN [Lookup].[Country] BA_C ON BA_C.Id = BA.CountryId
+		
+		-- Year-specific authorised representative from submission history
+		LEFT JOIN [Producer].[AuthorisedRepresentative] DPSH_AR ON DPSH_AR.Id = DPSH.AuthorisedRepresentativeId
+		
+		INNER JOIN [PCS].[EeeOutputReturnVersion] EORV ON EORV.Id = DPSH.EeeOutputReturnVersionId
+		INNER JOIN [PCS].[EeeOutputReturnVersionAmount] EORVA ON EORVA.EeeOutputReturnVersionId = EORV.Id
+		INNER JOIN [PCS].[EeeOutputAmount] EOA ON EOA.Id = EORVA.EeeOuputAmountId
+    WHERE
+        rp.Removed = 0 AND
+        eoa.ObligationType = @ObligationType AND
+        dps.ComplianceYear = (@ComplianceYear + 1) AND
+        dps.PaymentFinished = 1 AND
+        @SchemeId IS NULL AND
+		(@FilterByDirectRegistrant = 1 OR (@FilterBySchemes = 0 AND @FilterByDirectRegistrant = 0))
+
+    -- Create pivot table
+    SELECT EeeData.PRN, EeeData.ProducerName, EeeData.ProducerCountry, EeeData.SchemeId, 
+           EeeData.ApprovalNumber, EeeData.SchemeName, EeeData.Quarter,
+           [1] AS Cat1, [2] AS Cat2, [3] AS Cat3, [4] AS Cat4, [5] AS Cat5, [6] AS Cat6, [7] AS Cat7, 
+           [8] AS Cat8, [9] AS Cat9, [10] AS Cat10, [11] AS Cat11, [12] AS Cat12, [13] AS Cat13, [14] AS Cat14, [15] AS Cat15,
+           EeeData.IsDirectProducer
+    INTO #ProducerEEEData
+    FROM 
+    (
+        SELECT *
+        FROM #EEETable
+    ) AS p
+    PIVOT
+    (
+        MAX(p.Tonnage) 
+        FOR p.WeeeCategory IN ([1],[2],[3],[4],[5],[6],[7],[8],[9],[10],[11],[12],[13],[14],[15])
+    ) AS EeeData
+
+    -- Final result set
+    SELECT 
+        Producers.PRN, 
+        Producers.ProducerName, 
+        Producers.ProducerCountry, 
+        Producers.SchemeName, 
+        Producers.ApprovalNumber,
+        COALESCE(Totals.TotalTonnage, 0) AS 'TotalTonnage',
+        Q1.Cat1Q1, Q2.Cat1Q2, Q3.Cat1Q3, Q4.Cat1Q4,
+        Q1.Cat2Q1, Q2.Cat2Q2, Q3.Cat2Q3, Q4.Cat2Q4,
+        Q1.Cat3Q1, Q2.Cat3Q2, Q3.Cat3Q3, Q4.Cat3Q4,
+        Q1.Cat4Q1, Q2.Cat4Q2, Q3.Cat4Q3, Q4.Cat4Q4,
+        Q1.Cat5Q1, Q2.Cat5Q2, Q3.Cat5Q3, Q4.Cat5Q4,
+        Q1.Cat6Q1, Q2.Cat6Q2, Q3.Cat6Q3, Q4.Cat6Q4,
+        Q1.Cat7Q1, Q2.Cat7Q2, Q3.Cat7Q3, Q4.Cat7Q4,
+        Q1.Cat8Q1, Q2.Cat8Q2, Q3.Cat8Q3, Q4.Cat8Q4,
+        Q1.Cat9Q1, Q2.Cat9Q2, Q3.Cat9Q3, Q4.Cat9Q4,
+        Q1.Cat10Q1, Q2.Cat10Q2, Q3.Cat10Q3, Q4.Cat10Q4,
+        Q1.Cat11Q1, Q2.Cat11Q2, Q3.Cat11Q3, Q4.Cat11Q4,
+        Q1.Cat12Q1, Q2.Cat12Q2, Q3.Cat12Q3, Q4.Cat12Q4,
+        Q1.Cat13Q1, Q2.Cat13Q2, Q3.Cat13Q3, Q4.Cat13Q4,
+        Q1.Cat14Q1, Q2.Cat14Q2, Q3.Cat14Q3, Q4.Cat14Q4,
+        Q1.Cat15Q1, Q2.Cat15Q2, Q3.Cat15Q3, Q4.Cat15Q4
+    FROM (
+        SELECT PE.PRN, PE.SchemeId, PE.ApprovalNumber, PE.SchemeName, PE.ProducerName, PE.ProducerCountry, PE.IsDirectProducer
+        FROM #ProducerEEEData PE    
+        GROUP BY PE.PRN, PE.SchemeId, PE.ApprovalNumber, PE.SchemeName, PE.ProducerName, PE.ProducerCountry, PE.IsDirectProducer
+    ) AS Producers 
+    INNER JOIN (
+        SELECT E.PRN, E.SchemeId, SUM(COALESCE(E.Tonnage, 0)) AS 'TotalTonnage'
+        FROM #EEETable E
+        GROUP BY E.PRN, E.SchemeId
+    ) AS Totals ON (Producers.PRN = Totals.PRN AND Producers.SchemeId = Totals.SchemeId)
+    LEFT JOIN (
+        SELECT EEEData.PRN, EEEData.SchemeId, 
+               EEEData.Cat1 AS Cat1Q1, EEEData.Cat2 AS Cat2Q1, EEEData.Cat3 AS Cat3Q1, 
+               EEEData.Cat4 AS Cat4Q1, EEEData.Cat5 AS Cat5Q1, EEEData.Cat6 AS Cat6Q1, 
+               EEEData.Cat7 AS Cat7Q1, EEEData.Cat8 AS Cat8Q1, EEEData.Cat9 AS Cat9Q1, 
+               EEEData.Cat10 AS Cat10Q1, EEEData.Cat11 AS Cat11Q1, EEEData.Cat12 AS Cat12Q1,
+               EEEData.Cat13 AS Cat13Q1, EEEData.Cat14 AS Cat14Q1, EEEData.Cat15 AS Cat15Q1
+        FROM #ProducerEEEData EEEData
+        WHERE EEEData.Quarter = 1
+    ) AS Q1 ON (Producers.PRN = Q1.PRN AND Producers.SchemeId = Q1.SchemeId)
+    LEFT JOIN (
+        SELECT EEEData.PRN, EEEData.SchemeId,        
+               EEEData.Cat1 AS Cat1Q2, EEEData.Cat2 AS Cat2Q2, EEEData.Cat3 AS Cat3Q2, 
+               EEEData.Cat4 AS Cat4Q2, EEEData.Cat5 AS Cat5Q2, EEEData.Cat6 AS Cat6Q2, 
+               EEEData.Cat7 AS Cat7Q2, EEEData.Cat8 AS Cat8Q2, EEEData.Cat9 AS Cat9Q2, 
+               EEEData.Cat10 AS Cat10Q2, EEEData.Cat11 AS Cat11Q2, EEEData.Cat12 AS Cat12Q2,
+               EEEData.Cat13 AS Cat13Q2, EEEData.Cat14 AS Cat14Q2, EEEData.Cat15 AS Cat15Q2
+        FROM #ProducerEEEData EEEData
+        WHERE EEEData.Quarter = 2
+    ) AS Q2 ON (Producers.PRN = Q2.PRN AND Producers.SchemeId = Q2.SchemeId)
+    LEFT JOIN (
+        SELECT EEEData.PRN, EEEData.SchemeId, 
+               EEEData.Cat1 AS Cat1Q3, EEEData.Cat2 AS Cat2Q3, EEEData.Cat3 AS Cat3Q3, 
+               EEEData.Cat4 AS Cat4Q3, EEEData.Cat5 AS Cat5Q3, EEEData.Cat6 AS Cat6Q3, 
+               EEEData.Cat7 AS Cat7Q3, EEEData.Cat8 AS Cat8Q3, EEEData.Cat9 AS Cat9Q3, 
+               EEEData.Cat10 AS Cat10Q3, EEEData.Cat11 AS Cat11Q3, EEEData.Cat12 AS Cat12Q3,
+               EEEData.Cat13 AS Cat13Q3, EEEData.Cat14 AS Cat14Q3, EEEData.Cat15 AS Cat15Q3
+        FROM #ProducerEEEData EEEData
+        WHERE EEEData.Quarter = 3
+    ) AS Q3 ON (Producers.PRN = Q3.PRN AND Producers.SchemeId = Q3.SchemeId)
+    LEFT JOIN (
+        SELECT EEEData.PRN, EEEData.SchemeId, 
+               EEEData.Cat1 AS Cat1Q4, EEEData.Cat2 AS Cat2Q4, EEEData.Cat3 AS Cat3Q4, 
+               EEEData.Cat4 AS Cat4Q4, EEEData.Cat5 AS Cat5Q4, EEEData.Cat6 AS Cat6Q4, 
+               EEEData.Cat7 AS Cat7Q4, EEEData.Cat8 AS Cat8Q4, EEEData.Cat9 AS Cat9Q4, 
+               EEEData.Cat10 AS Cat10Q4, EEEData.Cat11 AS Cat11Q4, EEEData.Cat12 AS Cat12Q4,
+               EEEData.Cat13 AS Cat13Q4, EEEData.Cat14 AS Cat14Q4, EEEData.Cat15 AS Cat15Q4
+        FROM #ProducerEEEData EEEData
+        WHERE EEEData.Quarter = 4
+    ) AS Q4 ON (Producers.PRN = Q4.PRN AND Producers.SchemeId = Q4.SchemeId)
+    ORDER BY Producers.IsDirectProducer, SchemeName, ProducerName
+
+    -- Clean up temporary tables
+    DROP TABLE #EEETable
+    DROP TABLE #ProducerEEEData
+END


### PR DESCRIPTION
Added a new SQL script to modify the stored procedure `[Producer].[spgCSVDataBySchemeComplianceYearAndAuthorisedAuthority]` with significant enhancements:
- Introduced new parameters for filtering by direct registrants and schemes.
- Enhanced queries to include detailed fields for producer registration, scheme information, business details, and contact details.
- Added dynamic handling of `BrandNames` and subqueries for concatenating SIC codes and partner names.
- Introduced a `UNION ALL` query to handle direct registrant data with specific fields and logic.
- Improved filtering and sorting logic for compliance year, schemes, and removed producers.